### PR TITLE
Release v0.0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "sd-jwt-rs"
-version = "0.0.5"
+version = "0.0.6"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
-description = "Rust reference implementation of the IETF SD-JWT specification (v6)."
-rust-version = "1.74.0"
+description = "Rust reference implementation of the IETF SD-JWT specification (v7)."
+rust-version = "1.67.0"
 authors = ["Sergey Minaev <sergey.minaev@dsr-corporation.com>"]
 repository = "https://github.com/openwallet-foundation-labs/sd-jwt-rust"
+documentation = "https://docs.rs/sd-jwt-rs"
 homepage = "https://github.com/openwallet-foundation-labs/sd-jwt-rust"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ Proposals about API improvements are highly appreciated.
 ```rust
 fn demo() {
     let mut issuer = SDJWTIssuer::new(issuer_key, None);
-    let sd_jwt = issuer.issue_sd_jwt(claims, ClaimsForSelectiveDisclosureStrategy::AllLevels, holder_key, add_decoy, "compact".to_owned()).unwrap();
+    let sd_jwt = issuer.issue_sd_jwt(claims, ClaimsForSelectiveDisclosureStrategy::AllLevels, holder_key, add_decoy, SDJWTSerializationFormat::Compact).unwrap();
 
-    let mut holder = SDJWTHolder::new(sd_jwt, "compact".to_owned()).unwrap();
+    let mut holder = SDJWTHolder::new(sd_jwt, SDJWTSerializationFormat::Compact).unwrap();
     let presentation = holder.create_presentation(claims_to_disclosure, None, None, None, None).unwrap();
 
-    let verified_claims = SDJWTVerifier::new(presentation, cb_to_resolve_issuer_key, None, None, "compact".to_owned()).unwrap()
+    let verified_claims = SDJWTVerifier::new(presentation, cb_to_resolve_issuer_key, None, None, SDJWTSerializationFormat::Compact).unwrap()
                             .verified_claims;
 }
 ```
@@ -40,7 +40,7 @@ cargo test
 ```
 
 ### Interoperability testing tool
-Coming soon (planned for v0.0.6)
+Coming soon (planned for v0.0.7)
 
 ## External Dependencies
 


### PR DESCRIPTION
* Support SD-JWT standard of IETF draft v7 version
* API updates
* Bugfix for the issue#17
* Small improvements
* Bump crate version to 0.0.6