### PR TITLE
removed the 'sub' from always_revealed_root_keys

### DIFF
--- a/src/issuer.rs
+++ b/src/issuer.rs
@@ -193,7 +193,7 @@ impl SDJWTIssuer {
         let claims_obj_ref = user_claims
             .as_object_mut()
             .ok_or(Error::ConversionError("json object".to_string()))?;
-        let always_revealed_root_keys = vec!["sub", "iss", "iat", "exp"];
+        let always_revealed_root_keys = vec!["iss", "iat", "exp"];
         let mut always_revealed_claims: Map<String, Value> = always_revealed_root_keys
             .into_iter()
             .filter_map(|key| claims_obj_ref.remove_entry(key))

--- a/tests/demos.rs
+++ b/tests/demos.rs
@@ -45,7 +45,7 @@ fn address_flat<'a>() -> (
     usize,
 ) {
     let value = _address_claims();
-    let number_of_revealed_sds = 1;
+    let number_of_revealed_sds = 2; // 2 == 1('sub') + 1('address')
     (
         value.clone(),
         ClaimsForSelectiveDisclosureStrategy::TopLevel,
@@ -63,7 +63,15 @@ fn address_full_recursive<'a>() -> (
 ) {
     let value = _address_claims();
     let claims_to_disclose = value.as_object().unwrap().clone();
-    let number_of_revealed_sds = 5;
+
+    // revealed sds are:
+    //    sub
+    //    address
+    //    address.street_address
+    //    address.locality
+    //    address.region
+    //    address.country
+    let number_of_revealed_sds = 6;
     (
         value,
         ClaimsForSelectiveDisclosureStrategy::AllLevels,


### PR DESCRIPTION
According to the standard the 'sub' field can be selectively disclosable. This commit removes the 'sub' field from the list of always revealed keys.