### PR TITLE
fix: sd_hash generation and verification (#31)

### DIFF
--- a/src/holder.rs
+++ b/src/holder.rs
@@ -3,6 +3,7 @@ use error::{Error, Result};
 use jsonwebtoken::{Algorithm, EncodingKey, Header};
 use serde_json::{Map, Value};
 use std::collections::HashMap;
+use std::ops::Add;
 use std::str::FromStr;
 use std::time;
 
@@ -332,7 +333,9 @@ impl SDJWTHolder {
         let mut combined: Vec<&str> = Vec::with_capacity(self.hs_disclosures.len() + 1);
         combined.push(&self.serialized_sd_jwt);
         combined.extend(self.hs_disclosures.iter().map(|s| s.as_str()));
-        let combined = combined.join(COMBINED_SERIALIZATION_FORMAT_SEPARATOR);
+        let combined = combined
+            .join(COMBINED_SERIALIZATION_FORMAT_SEPARATOR)
+            .add(COMBINED_SERIALIZATION_FORMAT_SEPARATOR);
 
         let sd_hash = base64_hash(combined.as_bytes());
         self.key_binding_jwt_payload

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -5,6 +5,7 @@ use jsonwebtoken::jwk::Jwk;
 use jsonwebtoken::{Algorithm, DecodingKey, Header, Validation};
 use log::debug;
 use serde_json::{Map, Value};
+use std::ops::Add;
 use std::option::Option;
 use std::str::FromStr;
 use std::string::String;
@@ -213,7 +214,9 @@ impl SDJWTVerifier {
                 .iter()
                 .map(|s| s.as_str()),
         );
-        let combined = combined.join(COMBINED_SERIALIZATION_FORMAT_SEPARATOR);
+        let combined = combined
+            .join(COMBINED_SERIALIZATION_FORMAT_SEPARATOR)
+            .add(COMBINED_SERIALIZATION_FORMAT_SEPARATOR);
 
         Ok(base64_hash(combined.as_bytes()))
     }


### PR DESCRIPTION
- Fix generating `sd_hash` at holder side
- Fix retrieving `sd_hash` at verifier side
- Closes #31