### PR TITLE
Make code more rust idiomatic

### DIFF
--- a/src/holder.rs
+++ b/src/holder.rs
@@ -152,20 +152,10 @@ impl SDJWTHolder {
             .unwrap_or(&default_list)
             .iter()
             .filter_map(|digest| {
-                let digest = match digest.as_str() {
-                    Some(digest) => digest,
-                    None => return None,
-                };
-                if let Some(Value::Array(disclosure)) =
-                    self.sd_jwt_engine.hash_to_decoded_disclosure.get(digest)
-                {
-                    let key = match disclosure[1].as_str() {
-                        Some(digest) => digest,
-                        None => return None,
-                    };
-                    return Some((key, (&disclosure[2], digest)));
-                }
-                None
+                let digest = digest.as_str()?;
+                let disclosure = self.sd_jwt_engine.hash_to_decoded_disclosure.get(digest)?;
+                let key = disclosure[1].as_str()?;
+                Some((key, (&disclosure[2], digest)))
             })
             .collect(); //TODO split to 2 maps
         for (key_to_disclose, value_to_disclose) in claims_to_disclose {

--- a/src/holder.rs
+++ b/src/holder.rs
@@ -313,7 +313,7 @@ impl SDJWTHolder {
         self.set_key_binding_digest_key()?;
         // Create key-binding jwt
         let mut header = Header::new(
-            Algorithm::from_str(alg.as_str())
+            Algorithm::from_str(&alg)
                 .map_err(|e| Error::DeserializationError(e.to_string()))?,
         );
         header.typ = Some(crate::KB_JWT_TYP_HEADER.into());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,7 @@ impl SDJWTCommon {
             length: parts.len(),
             msg: format!("Invalid SD-JWT: {}", sd_jwt_with_disclosures),
         })?;
-        self.sign_alg = Self::decode_header_and_get_sign_algorithm(&sd_jwt);
+        self.sign_alg = Self::decode_header_and_get_sign_algorithm(sd_jwt);
         self.unverified_input_key_binding_jwt = Some(
             parts
                 .next_back()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ const CNF_KEY: &str = "cnf";
 const JWK_KEY: &str = "jwk";
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub(crate) struct SDJWTHasSDClaimException(String);
 
 impl SDJWTHasSDClaimException {}

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -76,7 +76,7 @@ impl SDJWTVerifier {
             let sign_alg = verifier.sd_jwt_engine.unverified_input_key_binding_jwt
                 .as_ref()
                 .and_then(|value| {
-                    SDJWTCommon::decode_header_and_get_sign_algorithm(&value)
+                    SDJWTCommon::decode_header_and_get_sign_algorithm(value)
                 });
 
             verifier.verify_key_binding_jwt(

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -180,10 +180,10 @@ impl SDJWTVerifier {
                     Algorithm::from_str(sign_alg)
                         .map_err(|e| Error::DeserializationError(e.to_string()))?,
                 );
-                validation.set_audience(&[expected_aud.as_str()]);
+                validation.set_audience(&[&expected_aud]);
                 validation.set_required_spec_claims(&["aud"]);
 
-                jsonwebtoken::decode::<Map<String, Value>>(payload.as_str(), &pubkey, &validation)
+                jsonwebtoken::decode::<Map<String, Value>>(&payload, &pubkey, &validation)
                     .map_err(|e| Error::DeserializationError(e.to_string()))?
             }
             None => {
@@ -216,7 +216,6 @@ impl SDJWTVerifier {
                 .unverified_sd_jwt
                 .as_ref()
                 .ok_or(Error::ConversionError("reference".to_string()))?
-                .as_str(),
         );
         combined.extend(
             self.sd_jwt_engine


### PR DESCRIPTION
I was having a read through the project and had some small suggestions. 

- Fixed the compiler warning from issue #39.
- Replaced some uses of if let, else if ... with match for enums. 

I couldn't find a todo list, is there one hosted somewhere? I was thinking of contributing to the project in a more meaningful way that style changes.