### PR TITLE
RFC 9901 §4.1: `exp` not mandated

### DIFF
--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -116,10 +116,14 @@ impl SDJWTVerifier {
                 .map_err(|e| Error::DeserializationError(e.to_string()))?,
             None => Algorithm::ES256, // Default or handle as needed
         };
+        let mut validation = Validation::new(algorithm);
+        // RFC 9901 §4.1: `exp` is not mandated, so don't require it. `validate_exp`
+        // stays true, so a present `exp` is still checked for expiry.
+        validation.required_spec_claims.remove("exp");
         let claims = jsonwebtoken::decode(
             sd_jwt,
             &issuer_public_key,
-            &Validation::new(algorithm),
+            &validation,
         )
             .map_err(|e| Error::DeserializationError(format!("Cannot decode jwt: {}", e)))?
             .claims;
@@ -1105,5 +1109,80 @@ mod tests {
             result.is_err(),
             "Verifier accepted presentation with unreferenced disclosure",
         );
+    }
+
+    #[test]
+    fn verify_presentation_without_exp() {
+        let user_claims = json!({
+            "sub": "6c5c0a49-b589-431d-bae7-219122a9ec2c",
+            "iss": "https://example.com/issuer",
+            "iat": 1683000000,
+            "address": { "country": "DE" }
+        });
+        let issuer_key = EncodingKey::from_ec_pem(PRIVATE_ISSUER_PEM.as_bytes()).unwrap();
+        let sd_jwt = SDJWTIssuer::new(issuer_key, None)
+            .issue_sd_jwt(
+                user_claims.clone(),
+                ClaimsForSelectiveDisclosureStrategy::AllLevels,
+                None,
+                false,
+                SDJWTSerializationFormat::Compact,
+            )
+            .unwrap();
+
+        let presentation = SDJWTHolder::new(sd_jwt, SDJWTSerializationFormat::Compact)
+            .unwrap()
+            .create_presentation(
+                user_claims.as_object().unwrap().clone(),
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        let result = SDJWTVerifier::new(
+            presentation,
+            Box::new(|_, _| DecodingKey::from_ec_pem(PUBLIC_ISSUER_PEM.as_bytes()).unwrap()),
+            None,
+            None,
+            SDJWTSerializationFormat::Compact,
+        );
+        assert!(result.is_ok(), "verifier rejected `exp`-less SD-JWT");
+    }
+
+    #[test]
+    fn reject_presentation_with_expired_exp() {
+        let user_claims = json!({
+            "sub": "6c5c0a49-b589-431d-bae7-219122a9ec2c",
+            "iss": "https://example.com/issuer",
+            "iat": 1683000000,
+            "exp": 1683000300,
+            "address": { "country": "DE" }
+        });
+        let issuer_key = EncodingKey::from_ec_pem(PRIVATE_ISSUER_PEM.as_bytes()).unwrap();
+        let sd_jwt = SDJWTIssuer::new(issuer_key, None)
+            .issue_sd_jwt(
+                user_claims.clone(),
+                ClaimsForSelectiveDisclosureStrategy::AllLevels,
+                None,
+                false,
+                SDJWTSerializationFormat::Compact,
+            )
+            .unwrap();
+
+        let result = SDJWTVerifier::new(
+            sd_jwt,
+            Box::new(|_, _| DecodingKey::from_ec_pem(PUBLIC_ISSUER_PEM.as_bytes()).unwrap()),
+            None,
+            None,
+            SDJWTSerializationFormat::Compact,
+        );
+        match result {
+            Ok(_) => panic!("verifier accepted a presentation with an expired `exp`"),
+            Err(err) => assert!(
+                err.to_string().contains("ExpiredSignature"),
+                "expected an expiry failure, got: {err}"
+            ),
+        }
     }
 }


### PR DESCRIPTION
## Problem

RFC 9901 §4.1 leaves the registered JWT claims of the Issuer-signed JWT to the
application rather than mandating any of them:

> The payload MAY contain further claims such as `iss`, `iat`, etc. as defined
> or required by the application using SD-JWTs.

In particular `exp` is not required by the base specification — whether an
expiration claim must be present is an application/profile decision.

The verifier decodes the Issuer-signed JWT with `Validation::new(algorithm)`.
jsonwebtoken's default `Validation` lists `exp` in `required_spec_claims`, so the
verifier rejects any otherwise-valid SD-JWT whose payload omits `exp`, failing
with a "missing required claim" error. That mandates `exp` more strictly than
RFC 9901 does and rejects spec-valid SD-JWTs that legitimately carry no
expiration.

## Change

Remove `exp` from `required_spec_claims` on the `Validation` before decoding, so
`exp` is no longer required. `validate_exp` keeps its default (`true`), so an
`exp` that *is* present is still checked for expiry — `exp` becomes
validated-if-present rather than mandatory.

## Test

`verify_presentation_without_exp`: issue, present, and verify an SD-JWT whose
payload carries `iss`/`iat` but no `exp`; the verifier accepts it.

`reject_presentation_with_expired_exp`: issue an SD-JWT whose payload carries a
past `exp` and verify it directly; the verifier rejects it with
`ExpiredSignature` — confirming `exp` is still validated when present.

`cargo test` is green: 23 lib + 128 integration + 1 doc = 152 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
