### PR TITLE
RFC 9901 §4.1: disallow `...` as a claim name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,10 +109,10 @@ impl SDJWTCommon {
         match the_object {
             Value::Object(obj) => {
                 for (key, value) in obj.iter() {
-                    if key == SD_DIGESTS_KEY {
+                    if key == SD_DIGESTS_KEY || key == SD_LIST_PREFIX {
                         return Err(Error::DataFieldMismatch(format!(
                             "Claim object cannot have `{}` field",
-                            SD_DIGESTS_KEY
+                            key
                         )));
                     } else {
                         Self::check_for_sd_claim(value)?;
@@ -231,6 +231,7 @@ impl SDJWTCommon {
 #[cfg(test)]
 mod tests {
     use crate::{utils, SDJWTCommon};
+    use serde_json::json;
 
 
     #[test]
@@ -253,5 +254,23 @@ mod tests {
         assert_eq!(sdjwt.unverified_sd_jwt.unwrap(), format!("jwt1.{encoded_empty_object}.jwt3"));
         assert_eq!(sdjwt.unverified_input_key_binding_jwt.unwrap(), "kbjwt");
         assert_eq!(sdjwt.input_disclosures, vec!["disc1".to_string(), "disc2".to_string()]);
+    }
+
+    #[test]
+    fn test_disallow_reserved_words_as_claim_names() {
+        for (claims, reserved) in [
+            (json!({ "_sd": "x" }), "_sd"),
+            (json!({ "...": "x" }), "..."),
+        ] {
+            let err = SDJWTCommon::check_for_sd_claim(&claims).unwrap_err();
+            assert!(
+                format!("{err}").contains("cannot have"),
+                "reserved word `{reserved}` was allowed as a claim name: {err}"
+            );
+        }
+        assert!(
+            SDJWTCommon::check_for_sd_claim(&json!({ "address": { "street": "x" } })).is_ok(),
+            "a claim object without reserved words was rejected"
+        );
     }
 }


### PR DESCRIPTION
## Problem

RFC 9901 §4.1 reserves the claim names `_sd` and `...` in the Issuer-signed JWT
payload:

> The payload MUST NOT contain the claims `_sd` or `...` except for the purpose
> of conveying digests as described in Sections 4.2.4.1 and 4.2.4.2,
> respectively.

`check_for_sd_claim` validates the Issuer's input claims before they are signed
into the payload. It already rejects `_sd`, but not `...`. An input object that
uses `...` as a claim name therefore passes validation, which would place a
non-digest `...` claim into the payload in violation of §4.1.

## Change

Extend the `check_for_sd_claim` reserved-name check to reject `...`
(`SD_LIST_PREFIX`, the array-element digest placeholder) in addition to `_sd`,
and report the offending key in the error message instead of always naming
`_sd`.

## Test

`test_disallow_reserved_words_as_claim_names`: assert `check_for_sd_claim`
rejects both `{ "_sd": ... }` and `{ "...": ... }` as claim names, and accepts a
normal nested claim object.

`cargo test` is green: 24 lib + 128 integration + 1 doc = 153 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
