### PR TITLE
RFC 9901 §4: compact format — SD-JWT vs SD-JWT+KB

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,6 @@ impl SDJWTCommon {
                 parts.len()
             )));
         }
-        let idx = parts.len();
         let mut parts = parts.into_iter();
         let sd_jwt = parts.next().ok_or(Error::IndexOutOfBounds {
             idx: 0,
@@ -148,19 +147,12 @@ impl SDJWTCommon {
             msg: format!("Invalid SD-JWT: {}", sd_jwt_with_disclosures),
         })?;
         self.sign_alg = Self::decode_header_and_get_sign_algorithm(sd_jwt);
-        self.unverified_input_key_binding_jwt = Some(
-            parts
-                .next_back()
-                .ok_or(Error::IndexOutOfBounds {
-                    idx: idx - 1,
-                    length: idx,
-                    msg: format!(
-                        "Invalid SD-JWT. Key binding not found: {}",
-                        sd_jwt_with_disclosures
-                    ),
-                })?
-                .to_owned(),
-        );
+        let trailing = parts.next_back().unwrap_or("");
+        self.unverified_input_key_binding_jwt = if trailing.is_empty() {
+            None
+        } else {
+            Some(trailing.to_owned())
+        };
         self.input_disclosures = parts.map(str::to_owned).collect();
         self.unverified_sd_jwt = Some(sd_jwt.to_owned());
 
@@ -240,7 +232,12 @@ mod tests {
         let encoded_empty_object = utils::base64url_encode("{}".as_bytes());
         sdjwt.parse_compact_sd_jwt(format!("jwt1.{encoded_empty_object}.jwt3~disc1~disc2~kbjwt")).unwrap();
         assert_eq!(sdjwt.unverified_sd_jwt.unwrap(), format!("jwt1.{encoded_empty_object}.jwt3"));
-        assert_eq!(sdjwt.unverified_input_key_binding_jwt.unwrap(), "kbjwt");
+        assert_eq!(sdjwt.unverified_input_key_binding_jwt.as_deref(), Some("kbjwt"));
+        assert_eq!(sdjwt.input_disclosures, vec!["disc1".to_string(), "disc2".to_string()]);
+
+        let mut sdjwt = SDJWTCommon::default();
+        sdjwt.parse_compact_sd_jwt(format!("jwt1.{encoded_empty_object}.jwt3~disc1~disc2~")).unwrap();
+        assert!(sdjwt.unverified_input_key_binding_jwt.is_none());
         assert_eq!(sdjwt.input_disclosures, vec!["disc1".to_string(), "disc2".to_string()]);
     }
 


### PR DESCRIPTION
## Problem

RFC 9901 §4 defines the compact serialization so that a plain SD-JWT always
ends with a tilde, and the Key Binding JWT — when present — comes after that
final tilde:

```
SD-JWT = JWT "~" *(DISCLOSURE "~")
SD-JWT-KB = SD-JWT KB-JWT
```

> The order of the concatenated parts MUST be the Issuer-signed JWT, a tilde
> character, zero or more Disclosures each followed by a tilde character, and
> lastly the optional Key Binding JWT.

> The two formats can be distinguished by the final `~` character that is
> present on an SD-JWT.

`parse_compact_sd_jwt` split on `~` and unconditionally took the last segment
as the Key Binding JWT. For a plain SD-JWT (`…~disc1~disc2~`) the trailing
tilde makes that segment the empty string, so the parser stored
`unverified_input_key_binding_jwt = Some("")` — claiming a Key Binding JWT
exists when none does. Code that branches on the `Option` then takes the wrong
path: e.g. verifying a KB-less presentation with `expected_aud`/`expected_nonce`
tried to decode `""` as a JWT and failed with an opaque deserialization error
instead of the explicit no-KB-JWT error. The JSON-serialization parser already
represents an absent KB-JWT as `None`, so the two parsers also disagreed.

## Change

Interpret the segment after the last `~` per §4: empty ⇒ `None` (plain SD-JWT),
non-empty ⇒ `Some(kb_jwt)` (SD-JWT+KB). Disclosures are unaffected. This also
removes an unreachable "Key binding not found" error branch (the
`parts.len() < 2` guard already rejects inputs without any `~`).

## Test

The compact parser test now covers both formats: `…~disc1~disc2~kbjwt` yields
`Some("kbjwt")`, and `…~disc1~disc2~` yields `None`, with the disclosure list
identical in both cases.

`cargo test` is green: 24 lib + 128 integration + 1 doc = 153 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
