### PR TITLE
RFC 9901 §8.1: New Unprotected Header Parameters [breaking]

### DIFF
--- a/src/holder.rs
+++ b/src/holder.rs
@@ -128,9 +128,9 @@ impl SDJWTHolder {
                 .sd_jwt_json
                 .take()
                 .ok_or(Error::InvalidState("Cannot take SDJWTJson".to_string()))?;
-            sd_jwt_json.disclosures = self.hs_disclosures.clone();
+            sd_jwt_json.header.disclosures = self.hs_disclosures.clone();
             if !self.serialized_key_binding_jwt.is_empty() {
-                sd_jwt_json.kb_jwt = Some(self.serialized_key_binding_jwt.clone());
+                sd_jwt_json.header.kb_jwt = Some(self.serialized_key_binding_jwt.clone());
             }
             serde_json::to_string(&sd_jwt_json)
                 .map_err(|e| Error::DeserializationError(e.to_string()))?

--- a/src/issuer.rs
+++ b/src/issuer.rs
@@ -346,12 +346,14 @@ impl SDJWTIssuer {
                     protected: jwt[0].to_owned(),
                     payload: jwt[1].to_owned(),
                     signature: jwt[2].to_owned(),
-                    kb_jwt: None,
-                    disclosures: self
-                        .all_disclosures
-                        .iter()
-                        .map(|d| d.raw_b64.to_string())
-                        .collect(),
+                    header: crate::SDJWTUnprotectedHeader {
+                        kb_jwt: None,
+                        disclosures: self
+                            .all_disclosures
+                            .iter()
+                            .map(|d| d.raw_b64.to_string())
+                            .collect(),
+                    },
                 };
                 self.serialized_sd_jwt = serde_json::to_string(&sd_jwt_json)
                     .map_err(|e| Error::DeserializationError(e.to_string()))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,13 @@ pub struct SDJWTJson {
     protected: String,
     payload: String,
     signature: String,
+    pub header: SDJWTUnprotectedHeader,
+}
+
+#[derive(Default, Serialize, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub struct SDJWTUnprotectedHeader {
     pub disclosures: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub kb_jwt: Option<String>,
 }
 
@@ -174,8 +180,8 @@ impl SDJWTCommon {
         let parsed_sd_jwt_json: SDJWTJson = serde_json::from_str(&sd_jwt_with_disclosures)
             .map_err(|e| Error::DeserializationError(e.to_string()))?;
         self.unverified_sd_jwt_json = Some(parsed_sd_jwt_json.clone());
-        self.unverified_input_key_binding_jwt = parsed_sd_jwt_json.kb_jwt;
-        self.input_disclosures = parsed_sd_jwt_json.disclosures;
+        self.unverified_input_key_binding_jwt = parsed_sd_jwt_json.header.kb_jwt;
+        self.input_disclosures = parsed_sd_jwt_json.header.disclosures;
         self.unverified_input_sd_jwt_payload =
             Some(jwt_payload_decode(&parsed_sd_jwt_json.payload)?);
         let sd_jwt = format!(
@@ -246,7 +252,7 @@ mod tests {
         let mut sdjwt = SDJWTCommon::default();
         let encoded_empty_object = utils::base64url_encode("{}".as_bytes());
         sdjwt.parse_json_sd_jwt(format!(
-            "{{\"protected\":\"jwt1\",\"payload\":\"{encoded_empty_object}\",\"signature\":\"jwt3\",\"disclosures\":[\"disc1\",\"disc2\"],\"kb_jwt\":\"kbjwt\"}}"
+            "{{\"protected\":\"jwt1\",\"payload\":\"{encoded_empty_object}\",\"signature\":\"jwt3\",\"header\":{{\"disclosures\":[\"disc1\",\"disc2\"],\"kb_jwt\":\"kbjwt\"}}}}"
         )).unwrap();
         assert_eq!(sdjwt.unverified_sd_jwt.unwrap(), format!("jwt1.{encoded_empty_object}.jwt3"));
         assert_eq!(sdjwt.unverified_input_key_binding_jwt.unwrap(), "kbjwt");

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -941,7 +941,7 @@ mod tests {
         let mut json: SDJWTJson = serde_json::from_str(&presentation).unwrap();
         let injected_disclosure =
             base64url_encode(br#"["injectedsalt", "injected_claim", "value"]"#);
-        json.disclosures.push(injected_disclosure);
+        json.header.disclosures.push(injected_disclosure);
         let tampered = serde_json::to_string(&json).unwrap();
 
         let result = SDJWTVerifier::new(
@@ -1007,7 +1007,7 @@ mod tests {
         // signature verification will pass — but the spec requires `iat` to
         // be present, and the verifier must reject this presentation.
         let mut json: SDJWTJson = serde_json::from_str(&presentation).unwrap();
-        let original_kb_jwt = json.kb_jwt.clone().unwrap();
+        let original_kb_jwt = json.header.kb_jwt.clone().unwrap();
         let kb_parts: Vec<&str> = original_kb_jwt.split('.').collect();
         let payload_bytes = base64url_decode(kb_parts[1]).unwrap();
         let mut kb_payload: Map<String, Value> =
@@ -1021,7 +1021,7 @@ mod tests {
         let tampered_kb_jwt =
             jsonwebtoken::encode(&header, &kb_payload, &resign_key).unwrap();
 
-        json.kb_jwt = Some(tampered_kb_jwt);
+        json.header.kb_jwt = Some(tampered_kb_jwt);
         let tampered_presentation = serde_json::to_string(&json).unwrap();
 
         let result = SDJWTVerifier::new(

--- a/tests/demos.rs
+++ b/tests/demos.rs
@@ -356,19 +356,20 @@ fn demo_positive_cases(
         let mut issued: SDJWTJson = serde_json::from_str(&issued).unwrap();
         let mut revealed: SDJWTJson = serde_json::from_str(&presentation).unwrap();
         let disclosures: Vec<String> = revealed
+            .header
             .disclosures
             .clone()
             .into_iter()
-            .filter(|d| issued.disclosures.contains(d))
+            .filter(|d| issued.header.disclosures.contains(d))
             .collect();
         assert_eq!(number_of_revealed_sds, disclosures.len());
 
         if holder_jwk.is_some() {
-            assert!(revealed.kb_jwt.is_some());
+            assert!(revealed.header.kb_jwt.is_some());
         }
 
-        issued.disclosures = disclosures;
-        revealed.kb_jwt = None;
+        issued.header.disclosures = disclosures;
+        revealed.header.kb_jwt = None;
         assert_eq!(revealed, issued);
     }
 


### PR DESCRIPTION
## Problem

RFC 9901 §8 ("JWS JSON Serialization") defines an OPTIONAL representation of an
SD-JWT / SD-JWT+KB based on the JWS JSON Serialization of [RFC7515]. Per §8.1,
the Disclosures and the optional Key Binding JWT are carried as **unprotected
header parameters** — i.e. inside the JWS `header` member — not as top-level
members of the JSON object.

The crate's `SDJWTJson` placed `disclosures` and `kb_jwt` as top-level fields
alongside `protected` / `payload` / `signature`, so the emitted JSON did not
match the structure shown in RFC 9901 §8.2 and would not interoperate with
conforming implementations.

## Change

Add `SDJWTUnprotectedHeader { disclosures, kb_jwt }` and nest it under a new
`header` member of `SDJWTJson`, per §8.1 (carried in the unprotected header):

```json
{
  "header": {
    "disclosures": ["...", "..."],
    "kb_jwt": "..."
  },
  "payload": "...",
  "protected": "...",
  "signature": "..."
}
```

- `kb_jwt` uses `skip_serializing_if = "Option::is_none"`, so it is emitted only
  for an SD-JWT+KB — per §8.1: "Present only in an SD-JWT+KB".
- Issuer, Holder, and Verifier are updated to read/write the nested members.

This is a **breaking change to the JSON wire format**: JSON produced by earlier
versions (top-level `disclosures` / `kb_jwt`) no longer parses, and vice versa.
The Compact Serialization is unaffected.

Scope: this implements the Flattened JSON Serialization (§8.2 — a single
unprotected header). General JSON Serialization (§8.3, multiple unprotected
headers) remains out of scope.

## Test

- `parse_json_sd_jwt` unit test updated to the nested `header` shape.
- Verifier tamper tests (disclosure injection, KB-JWT tampering) updated to
  mutate `header.disclosures` / `header.kb_jwt`.
- `tests/demos.rs` JSON round-trip updated.
- Full suite green: 153 (24 lib + 128 integration + 1 doc).

## Reference — RFC 9901 §8.1, New Unprotected Header Parameters (verbatim)

> For both the General and Flattened JSON Serialization, the SD-JWT or SD-JWT+KB
> is represented as a JSON object according to Section 7.2 of [RFC7515]. The
> following new unprotected header parameters are defined:
>
> disclosures: An array of strings where each element is an individual
> Disclosure as described in Section 4.2.
>
> kb_jwt: Present only in an SD-JWT+KB, the Key Binding JWT as described in
> Section 4.3.

RFC 9901 §8.2 shows this non-normative example of a Flattened JSON serialized
SD-JWT (base64url values abbreviated):

```json
{
  "header": {
    "disclosures": ["WyIyR0xD...", "WyJlbHVW...", "..."]
  },
  "payload": "eyJfc2QiOi...",
  "protected": "eyJhbGciOi...",
  "signature": "3oOtvPxU..."
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
