### PR TITLE
RFC 9901 §8.3: General JSON Serialization, rename JSON→FlattenedJson [breaking]

### DIFF
--- a/src/holder.rs
+++ b/src/holder.rs
@@ -2,7 +2,10 @@
 // https://www.dsr-corporation.com
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{error, SDJWTJson, SDJWTSerializationFormat};
+use crate::{
+    error, SDJWTFlattenedJson, SDJWTGeneralJson, SDJWTGeneralJsonSignature, SDJWTSerializationFormat,
+    SDJWTUnprotectedHeader,
+};
 use error::{Error, Result};
 use jsonwebtoken::{Algorithm, EncodingKey, Header};
 use serde_json::{Map, Value};
@@ -14,8 +17,8 @@ use std::time;
 use crate::utils::base64_hash;
 use crate::SDJWTCommon;
 use crate::{
-    COMBINED_SERIALIZATION_FORMAT_SEPARATOR, DEFAULT_SIGNING_ALG, KB_DIGEST_KEY, SD_DIGESTS_KEY,
-    SD_LIST_PREFIX,
+    COMBINED_SERIALIZATION_FORMAT_SEPARATOR, DEFAULT_SIGNING_ALG, KB_DIGEST_KEY, KB_JWT_TYP_HEADER,
+    SD_DIGESTS_KEY, SD_LIST_PREFIX,
 };
 
 pub struct SDJWTHolder {
@@ -26,7 +29,6 @@ pub struct SDJWTHolder {
     serialized_key_binding_jwt: String,
     sd_jwt_payload: Map<String, Value>,
     serialized_sd_jwt: String,
-    sd_jwt_json: Option<SDJWTJson>,
 }
 
 impl SDJWTHolder {
@@ -55,7 +57,6 @@ impl SDJWTHolder {
             serialized_key_binding_jwt: "".to_string(),
             sd_jwt_payload: Map::new(),
             serialized_sd_jwt: "".to_string(),
-            sd_jwt_json: None,
         };
 
         holder
@@ -73,7 +74,6 @@ impl SDJWTHolder {
             .unverified_sd_jwt
             .take()
             .ok_or(Error::InvalidState("Cannot take jwt".to_string()))?;
-        holder.sd_jwt_json = holder.sd_jwt_engine.unverified_sd_jwt_json.clone();
 
         holder.sd_jwt_engine.create_hash_mappings()?;
 
@@ -116,24 +116,48 @@ impl SDJWTHolder {
             }
         }
 
-        let sd_jwt_presentation = if self.sd_jwt_engine.serialization_format == SDJWTSerializationFormat::Compact {
-            let mut combined: Vec<&str> = Vec::with_capacity(self.hs_disclosures.len() + 2);
-            combined.push(&self.serialized_sd_jwt);
-            combined.extend(self.hs_disclosures.iter().map(|s| s.as_str()));
-            combined.push(&self.serialized_key_binding_jwt);
-            let joined = combined.join(COMBINED_SERIALIZATION_FORMAT_SEPARATOR);
-            joined.to_string()
-        } else {
-            let mut sd_jwt_json = self
-                .sd_jwt_json
-                .take()
-                .ok_or(Error::InvalidState("Cannot take SDJWTJson".to_string()))?;
-            sd_jwt_json.header.disclosures = self.hs_disclosures.clone();
-            if !self.serialized_key_binding_jwt.is_empty() {
-                sd_jwt_json.header.kb_jwt = Some(self.serialized_key_binding_jwt.clone());
+        let sd_jwt_presentation = match self.sd_jwt_engine.serialization_format {
+            SDJWTSerializationFormat::Compact => {
+                let mut combined: Vec<&str> = Vec::with_capacity(self.hs_disclosures.len() + 2);
+                combined.push(&self.serialized_sd_jwt);
+                combined.extend(self.hs_disclosures.iter().map(|s| s.as_str()));
+                combined.push(&self.serialized_key_binding_jwt);
+                combined.join(COMBINED_SERIALIZATION_FORMAT_SEPARATOR)
             }
-            serde_json::to_string(&sd_jwt_json)
+            SDJWTSerializationFormat::FlattenedJson => {
+                let (protected, payload, signature) =
+                    SDJWTCommon::split_jwt(&self.serialized_sd_jwt)?;
+                let header = SDJWTUnprotectedHeader {
+                    disclosures: self.hs_disclosures.clone(),
+                    kb_jwt: (!self.serialized_key_binding_jwt.is_empty())
+                        .then(|| self.serialized_key_binding_jwt.clone()),
+                };
+                serde_json::to_string(&SDJWTFlattenedJson {
+                    protected,
+                    payload,
+                    signature,
+                    header,
+                })
                 .map_err(|e| Error::DeserializationError(e.to_string()))?
+            }
+            SDJWTSerializationFormat::GeneralJson => {
+                let (protected, payload, signature) =
+                    SDJWTCommon::split_jwt(&self.serialized_sd_jwt)?;
+                let header = SDJWTUnprotectedHeader {
+                    disclosures: self.hs_disclosures.clone(),
+                    kb_jwt: (!self.serialized_key_binding_jwt.is_empty())
+                        .then(|| self.serialized_key_binding_jwt.clone()),
+                };
+                serde_json::to_string(&SDJWTGeneralJson {
+                    payload,
+                    signatures: vec![SDJWTGeneralJsonSignature {
+                        protected,
+                        signature,
+                        header,
+                    }],
+                })
+                .map_err(|e| Error::DeserializationError(e.to_string()))?
+            }
         };
 
         Ok(sd_jwt_presentation)
@@ -299,7 +323,7 @@ impl SDJWTHolder {
         self.key_binding_jwt_header
             .insert("alg".to_string(), alg.clone().into());
         self.key_binding_jwt_header
-            .insert("typ".to_string(), crate::KB_JWT_TYP_HEADER.into());
+            .insert("typ".to_string(), KB_JWT_TYP_HEADER.into());
         self.key_binding_jwt_payload
             .insert("nonce".to_string(), nonce.into());
         self.key_binding_jwt_payload
@@ -316,7 +340,7 @@ impl SDJWTHolder {
             Algorithm::from_str(&alg)
                 .map_err(|e| Error::DeserializationError(e.to_string()))?,
         );
-        header.typ = Some(crate::KB_JWT_TYP_HEADER.into());
+        header.typ = Some(KB_JWT_TYP_HEADER.into());
         self.serialized_key_binding_jwt =
             jsonwebtoken::encode(&header, &self.key_binding_jwt_payload, holder_key)
                 .map_err(|e| Error::DeserializationError(e.to_string()))?;

--- a/src/issuer.rs
+++ b/src/issuer.rs
@@ -2,7 +2,9 @@
 // https://www.dsr-corporation.com
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{error, SDJWTJson};
+use crate::{
+    error, SDJWTFlattenedJson, SDJWTGeneralJson, SDJWTGeneralJsonSignature, SDJWTUnprotectedHeader,
+};
 use error::Result;
 use std::collections::{HashMap, VecDeque};
 use std::str::FromStr;
@@ -334,28 +336,44 @@ impl SDJWTIssuer {
                     COMBINED_SERIALIZATION_FORMAT_SEPARATOR,
                 );
             },
-            SDJWTSerializationFormat::JSON => {
-                let jwt: Vec<&str> = self.signed_sd_jwt.split('.').collect();
-                if jwt.len() != 3 {
-                    return Err(Error::InvalidInput(format!(
-                        "Invalid JWT, JWT must contain three parts after splitting with \".\": jwt {}",
-                        self.signed_sd_jwt
-                    )));
-                }
-                let sd_jwt_json = SDJWTJson {
-                    protected: jwt[0].to_owned(),
-                    payload: jwt[1].to_owned(),
-                    signature: jwt[2].to_owned(),
-                    header: crate::SDJWTUnprotectedHeader {
-                        kb_jwt: None,
-                        disclosures: self
-                            .all_disclosures
-                            .iter()
-                            .map(|d| d.raw_b64.to_string())
-                            .collect(),
-                    },
+            SDJWTSerializationFormat::FlattenedJson => {
+                let (protected, payload, signature) = SDJWTCommon::split_jwt(&self.signed_sd_jwt)?;
+                let header = SDJWTUnprotectedHeader {
+                    kb_jwt: None,
+                    disclosures: self
+                        .all_disclosures
+                        .iter()
+                        .map(|d| d.raw_b64.to_string())
+                        .collect(),
                 };
-                self.serialized_sd_jwt = serde_json::to_string(&sd_jwt_json)
+                let flattened_json = SDJWTFlattenedJson {
+                    protected,
+                    payload,
+                    signature,
+                    header,
+                };
+                self.serialized_sd_jwt = serde_json::to_string(&flattened_json)
+                    .map_err(|e| Error::DeserializationError(e.to_string()))?;
+            }
+            SDJWTSerializationFormat::GeneralJson => {
+                let (protected, payload, signature) = SDJWTCommon::split_jwt(&self.signed_sd_jwt)?;
+                let header = SDJWTUnprotectedHeader {
+                    kb_jwt: None,
+                    disclosures: self
+                        .all_disclosures
+                        .iter()
+                        .map(|d| d.raw_b64.to_string())
+                        .collect(),
+                };
+                let general_json = SDJWTGeneralJson {
+                    payload,
+                    signatures: vec![SDJWTGeneralJsonSignature {
+                        protected,
+                        signature,
+                        header,
+                    }],
+                };
+                self.serialized_sd_jwt = serde_json::to_string(&general_json)
                     .map_err(|e| Error::DeserializationError(e.to_string()))?;
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,6 +211,11 @@ impl SDJWTCommon {
     fn parse_general_json_sd_jwt(&mut self, sd_jwt_with_disclosures: String) -> Result<()> {
         let parsed: SDJWTGeneralJson = serde_json::from_str(&sd_jwt_with_disclosures)
             .map_err(|e| Error::DeserializationError(e.to_string()))?;
+        if parsed.signatures.len() > 1 {
+            return Err(Error::InvalidInput(
+                "General JSON SD-JWT with multiple signatures is not supported yet".to_string(),
+            ));
+        }
         // RFC 9901 §8.3: in General JSON Serialization, the Disclosures and the
         // optional KB-JWT live in the first signature's unprotected header.
         let signature = parsed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,9 +41,11 @@ impl SDJWTHasSDClaimException {}
 /// SDJWTSerializationFormat is used to determine how an SD-JWT is serialized to String
 #[derive(Default, Clone, PartialEq, Debug, Display)]
 pub enum SDJWTSerializationFormat {
-    /// JSON-encoded representation
+    /// Flattened JWS JSON representation
     #[default]
-    JSON,
+    FlattenedJson,
+    /// General JWS JSON representation
+    GeneralJson,
     /// Base64-encoded representation
     Compact,
 }
@@ -54,7 +56,6 @@ pub(crate) struct SDJWTCommon {
     serialization_format: SDJWTSerializationFormat,
     unverified_input_key_binding_jwt: Option<String>,
     unverified_sd_jwt: Option<String>,
-    unverified_sd_jwt_json: Option<SDJWTJson>,
     unverified_input_sd_jwt_payload: Option<Map<String, Value>>,
     hash_to_decoded_disclosure: HashMap<String, Value>,
     hash_to_disclosure: HashMap<String, String>,
@@ -63,9 +64,22 @@ pub(crate) struct SDJWTCommon {
 }
 
 #[derive(Default, Serialize, Deserialize, Clone, Eq, PartialEq, Debug)]
-pub struct SDJWTJson {
+pub struct SDJWTFlattenedJson {
     protected: String,
     payload: String,
+    signature: String,
+    pub header: SDJWTUnprotectedHeader,
+}
+
+#[derive(Default, Serialize, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub struct SDJWTGeneralJson {
+    payload: String,
+    pub signatures: Vec<SDJWTGeneralJsonSignature>,
+}
+
+#[derive(Default, Serialize, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub struct SDJWTGeneralJsonSignature {
+    protected: String,
     signature: String,
     pub header: SDJWTUnprotectedHeader,
 }
@@ -176,22 +190,45 @@ impl SDJWTCommon {
         Ok(())
     }
 
-    fn parse_json_sd_jwt(&mut self, sd_jwt_with_disclosures: String) -> Result<()> {
-        let parsed_sd_jwt_json: SDJWTJson = serde_json::from_str(&sd_jwt_with_disclosures)
+    fn parse_flattened_json_sd_jwt(&mut self, sd_jwt_with_disclosures: String) -> Result<()> {
+        let parsed: SDJWTFlattenedJson = serde_json::from_str(&sd_jwt_with_disclosures)
             .map_err(|e| Error::DeserializationError(e.to_string()))?;
-        self.unverified_sd_jwt_json = Some(parsed_sd_jwt_json.clone());
-        self.unverified_input_key_binding_jwt = parsed_sd_jwt_json.header.kb_jwt;
-        self.input_disclosures = parsed_sd_jwt_json.header.disclosures;
+        self.unverified_input_key_binding_jwt = parsed.header.kb_jwt;
+        self.input_disclosures = parsed.header.disclosures;
         self.unverified_input_sd_jwt_payload =
-            Some(jwt_payload_decode(&parsed_sd_jwt_json.payload)?);
+            Some(jwt_payload_decode(&parsed.payload)?);
         let sd_jwt = format!(
             "{}.{}.{}",
-            parsed_sd_jwt_json.protected,
-            parsed_sd_jwt_json.payload,
-            parsed_sd_jwt_json.signature
+            parsed.protected,
+            parsed.payload,
+            parsed.signature
         );    
         self.unverified_sd_jwt = Some(sd_jwt.clone());
         self.sign_alg = Self::decode_header_and_get_sign_algorithm(&sd_jwt);    
+        Ok(())
+    }
+
+    fn parse_general_json_sd_jwt(&mut self, sd_jwt_with_disclosures: String) -> Result<()> {
+        let parsed: SDJWTGeneralJson = serde_json::from_str(&sd_jwt_with_disclosures)
+            .map_err(|e| Error::DeserializationError(e.to_string()))?;
+        // RFC 9901 §8.3: in General JSON Serialization, the Disclosures and the
+        // optional KB-JWT live in the first signature's unprotected header.
+        let signature = parsed
+            .signatures
+            .into_iter()
+            .next()
+            .ok_or(Error::InvalidInput(
+                "General JSON SD-JWT must contain at least one signature".to_string(),
+            ))?;
+        self.unverified_input_key_binding_jwt = signature.header.kb_jwt;
+        self.input_disclosures = signature.header.disclosures;
+        self.unverified_input_sd_jwt_payload = Some(jwt_payload_decode(&parsed.payload)?);
+        let sd_jwt = format!(
+            "{}.{}.{}",
+            signature.protected, parsed.payload, signature.signature
+        );
+        self.unverified_sd_jwt = Some(sd_jwt.clone());
+        self.sign_alg = Self::decode_header_and_get_sign_algorithm(&sd_jwt);
         Ok(())
     }
 
@@ -200,8 +237,11 @@ impl SDJWTCommon {
             SDJWTSerializationFormat::Compact => {
                 self.parse_compact_sd_jwt(sd_jwt_with_disclosures)
             }
-            SDJWTSerializationFormat::JSON => {
-                self.parse_json_sd_jwt(sd_jwt_with_disclosures)
+            SDJWTSerializationFormat::FlattenedJson => {
+                self.parse_flattened_json_sd_jwt(sd_jwt_with_disclosures)
+            }
+            SDJWTSerializationFormat::GeneralJson => {
+                self.parse_general_json_sd_jwt(sd_jwt_with_disclosures)
             }
         }
     }
@@ -223,6 +263,17 @@ impl SDJWTCommon {
             .and_then(Value::as_str)
             .map(String::from);
         sign_alg
+    }
+
+    /// Splits a signed JWT (`protected.payload.signature`) into its three parts.
+    fn split_jwt(jwt: &str) -> Result<(String, String, String)> {
+        let parts: Vec<&str> = jwt.split('.').collect();
+        let [protected, payload, signature] = parts.as_slice() else {
+            return Err(Error::InvalidState(format!(
+                "Invalid signed JWT, expected three parts: {jwt}"
+            )));
+        };
+        Ok((protected.to_string(), payload.to_string(), signature.to_string()))
     }
 }
 
@@ -248,15 +299,29 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_json_sd_jwt() {
+    fn test_parse_flattened_json_sd_jwt() {
         let mut sdjwt = SDJWTCommon::default();
         let encoded_empty_object = utils::base64url_encode("{}".as_bytes());
-        sdjwt.parse_json_sd_jwt(format!(
-            "{{\"protected\":\"jwt1\",\"payload\":\"{encoded_empty_object}\",\"signature\":\"jwt3\",\"header\":{{\"disclosures\":[\"disc1\",\"disc2\"],\"kb_jwt\":\"kbjwt\"}}}}"
+        sdjwt.parse_flattened_json_sd_jwt(format!(
+            r#"{{"protected":"jwt1","payload":"{encoded_empty_object}","signature":"jwt3","header":{{"disclosures":["disc1","disc2"],"kb_jwt":"kbjwt"}}}}"#
         )).unwrap();
         assert_eq!(sdjwt.unverified_sd_jwt.unwrap(), format!("jwt1.{encoded_empty_object}.jwt3"));
         assert_eq!(sdjwt.unverified_input_key_binding_jwt.unwrap(), "kbjwt");
         assert_eq!(sdjwt.input_disclosures, vec!["disc1".to_string(), "disc2".to_string()]);
+    }
+
+    #[test]
+    fn test_parse_general_json_rejects_empty_signatures() {
+        // `signatures` is a Vec, so serde accepts `[]`; the parser must reject a
+        // signature-less input explicitly rather than panic on `signatures[0]`.
+        let mut sdjwt = SDJWTCommon::default();
+        let err = sdjwt
+            .parse_general_json_sd_jwt(r#"{"payload":"e30","signatures":[]}"#.to_string())
+            .unwrap_err();
+        assert!(
+            format!("{err}").contains("at least one signature"),
+            "empty `signatures` array should be rejected: {err}"
+        );
     }
 
     #[test]

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -987,6 +987,49 @@ mod tests {
     }
 
     #[test]
+    fn reject_general_json_with_multiple_signatures() {
+        let user_claims = json!({
+            "iss": "https://example.com/issuer",
+            "iat": 1683000000,
+            "sub": "6c5c0a49-b589-431d-bae7-219122a9ec2c",
+        });
+
+        let private_issuer_bytes = PRIVATE_ISSUER_PEM.as_bytes();
+        let issuer_key = EncodingKey::from_ec_pem(private_issuer_bytes).unwrap();
+
+        let sd_jwt = SDJWTIssuer::new(issuer_key, Some("ES256".to_string()))
+            .issue_sd_jwt(
+                user_claims,
+                ClaimsForSelectiveDisclosureStrategy::AllLevels,
+                None,
+                false,
+                SDJWTSerializationFormat::GeneralJson,
+            )
+            .unwrap();
+
+        let mut json: SDJWTGeneralJson = serde_json::from_str(&sd_jwt).unwrap();
+        let duplicated = json.signatures[0].clone();
+        json.signatures.push(duplicated);
+        let tampered = serde_json::to_string(&json).unwrap();
+
+        let result = SDJWTVerifier::new(
+            tampered,
+            Box::new(|_, _| {
+                let public_issuer_bytes = PUBLIC_ISSUER_PEM.as_bytes();
+                DecodingKey::from_ec_pem(public_issuer_bytes).unwrap()
+            }),
+            None,
+            None,
+            SDJWTSerializationFormat::GeneralJson,
+        );
+
+        assert!(
+            result.is_err(),
+            "Verifier accepted a General JSON SD-JWT with multiple signatures",
+        );
+    }
+
+    #[test]
     fn reject_kb_jwt_missing_iat_claim() {
         let user_claims = json!({
             "address": {

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -433,8 +433,9 @@ impl SDJWTVerifier {
 mod tests {
     use crate::issuer::ClaimsForSelectiveDisclosureStrategy;
     use crate::utils::{base64url_decode, base64url_encode};
-    use crate::{SDJWTHolder, SDJWTIssuer, SDJWTJson, SDJWTVerifier, SDJWTSerializationFormat, COMBINED_SERIALIZATION_FORMAT_SEPARATOR};
+    use crate::{SDJWTHolder, SDJWTIssuer, SDJWTFlattenedJson, SDJWTGeneralJson, SDJWTVerifier, SDJWTSerializationFormat, COMBINED_SERIALIZATION_FORMAT_SEPARATOR};
     use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header};
+    use rstest::rstest;
     use serde_json::{json, Map, Value};
 
     const PRIVATE_ISSUER_PEM: &str = "-----BEGIN PRIVATE KEY-----\nMIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgUr2bNKuBPOrAaxsR\nnbSH6hIhmNTxSGXshDSUD1a1y7ihRANCAARvbx3gzBkyPDz7TQIbjF+ef1IsxUwz\nX1KWpmlVv+421F7+c1sLqGk4HUuoVeN8iOoAcE547pJhUEJyf5Asc6pP\n-----END PRIVATE KEY-----\n";
@@ -770,7 +771,7 @@ mod tests {
     }
 
     #[test]
-    fn verify_full_presentation_to_allow_other_algorithms_json_format() {
+    fn verify_full_presentation_to_allow_other_algorithms() {
 
         let user_claims = json!({
             "sub": "6c5c0a49-b589-431d-bae7-219122a9ec2c",
@@ -791,11 +792,11 @@ mod tests {
             ClaimsForSelectiveDisclosureStrategy::AllLevels,
             None,
             false,
-            SDJWTSerializationFormat::JSON, // Changed to Json format
+            SDJWTSerializationFormat::FlattenedJson, // Changed to Flattened Json format
         )
             .unwrap();
        
-        let presentation = SDJWTHolder::new(sd_jwt.clone(), SDJWTSerializationFormat::JSON) // Changed to Json format
+        let presentation = SDJWTHolder::new(sd_jwt.clone(), SDJWTSerializationFormat::FlattenedJson) // Changed to Flattened Json format
             .unwrap()
             .create_presentation(
                 user_claims.as_object().unwrap().clone(),
@@ -814,7 +815,7 @@ mod tests {
             }),
             None,
             None,
-            SDJWTSerializationFormat::JSON, // Changed to Json format
+            SDJWTSerializationFormat::FlattenedJson, // Changed to Flattened Json format
         )
             .unwrap()
             .verified_claims;
@@ -847,7 +848,7 @@ mod tests {
             ClaimsForSelectiveDisclosureStrategy::AllLevels,
             Some(serde_json::from_str(HOLDER_JWK_KEY_ED25519).unwrap()),
             false,
-            SDJWTSerializationFormat::JSON, // Changed to Json format
+            SDJWTSerializationFormat::FlattenedJson, // Changed to Flattened Json format
         ).unwrap();
 
         let private_holder_bytes = HOLDER_KEY_ED25519.as_bytes();
@@ -856,7 +857,7 @@ mod tests {
         let nonce = Some(String::from("testNonce"));
         let aud = Some(String::from("testAud"));
 
-        let mut holder = SDJWTHolder::new(sd_jwt.clone(), SDJWTSerializationFormat::JSON).unwrap(); // Changed to Json format
+        let mut holder = SDJWTHolder::new(sd_jwt.clone(), SDJWTSerializationFormat::FlattenedJson).unwrap(); // Changed to Flattened Json format
         let presentation = holder.create_presentation(
                 user_claims.as_object().unwrap().clone(),
                 nonce.clone(),
@@ -873,7 +874,7 @@ mod tests {
             }),
             aud.clone(),
             nonce.clone(),
-            SDJWTSerializationFormat::JSON, // Changed to Json format
+            SDJWTSerializationFormat::FlattenedJson, // Changed to Flattened Json format
         )
             .unwrap()
             .verified_claims;
@@ -892,8 +893,13 @@ mod tests {
         assert_eq!(claims_to_check, verified_claims);
     }
 
-    #[test]
-    fn reject_tampered_json_presentation_with_injected_disclosure() {
+    #[rstest]
+    #[case::flattened(SDJWTSerializationFormat::FlattenedJson)]
+    #[case::general(SDJWTSerializationFormat::GeneralJson)]
+    #[case::compact(SDJWTSerializationFormat::Compact)]
+    fn reject_tampered_presentation_with_injected_disclosure(
+        #[case] format: SDJWTSerializationFormat,
+    ) {
         let user_claims = json!({
             "address": {
                 "street_address": "Schulstr. 12",
@@ -915,7 +921,7 @@ mod tests {
             ClaimsForSelectiveDisclosureStrategy::AllLevels,
             Some(serde_json::from_str(HOLDER_JWK_KEY_ED25519).unwrap()),
             false,
-            SDJWTSerializationFormat::JSON,
+            format.clone(),
         ).unwrap();
 
         let private_holder_bytes = HOLDER_KEY_ED25519.as_bytes();
@@ -923,7 +929,7 @@ mod tests {
         let nonce = Some(String::from("testNonce"));
         let aud = Some(String::from("testAud"));
 
-        let presentation = SDJWTHolder::new(sd_jwt, SDJWTSerializationFormat::JSON)
+        let presentation = SDJWTHolder::new(sd_jwt, format.clone())
             .unwrap()
             .create_presentation(
                 user_claims.as_object().unwrap().clone(),
@@ -934,15 +940,34 @@ mod tests {
             )
             .unwrap();
 
-        // Tamper: inject a syntactically-valid extra disclosure into the JSON
-        // presentation. The KB-JWT's sd_hash was computed by the holder over
-        // the original disclosure list, so the verifier MUST detect the
-        // mismatch on the augmented presentation.
-        let mut json: SDJWTJson = serde_json::from_str(&presentation).unwrap();
+        // Tamper: inject a syntactically-valid extra disclosure into the presentation.
+        // The KB-JWT's sd_hash was computed by the holder over the original disclosure
+        // list, so the verifier MUST detect the mismatch. Where the disclosure goes
+        // differs by format: a `~`-separated segment before the KB-JWT (Compact §4),
+        // a top-level `header` member (Flattened §8.2), or the first signature's
+        // header (General §8.3).
         let injected_disclosure =
             base64url_encode(br#"["injectedsalt", "injected_claim", "value"]"#);
-        json.header.disclosures.push(injected_disclosure);
-        let tampered = serde_json::to_string(&json).unwrap();
+        let tampered = match format {
+            SDJWTSerializationFormat::FlattenedJson => {
+                let mut json: SDJWTFlattenedJson = serde_json::from_str(&presentation).unwrap();
+                json.header.disclosures.push(injected_disclosure);
+                serde_json::to_string(&json).unwrap()
+            }
+            SDJWTSerializationFormat::GeneralJson => {
+                let mut json: SDJWTGeneralJson = serde_json::from_str(&presentation).unwrap();
+                json.signatures[0].header.disclosures.push(injected_disclosure);
+                serde_json::to_string(&json).unwrap()
+            }
+            SDJWTSerializationFormat::Compact => {
+                // presentation = "<jwt>~<disclosures…>~<kb_jwt>"; splice the extra
+                // disclosure in just before the trailing KB-JWT segment.
+                let mut parts: Vec<&str> =
+                    presentation.split(COMBINED_SERIALIZATION_FORMAT_SEPARATOR).collect();
+                parts.insert(parts.len() - 1, &injected_disclosure);
+                parts.join(COMBINED_SERIALIZATION_FORMAT_SEPARATOR)
+            }
+        };
 
         let result = SDJWTVerifier::new(
             tampered,
@@ -952,12 +977,12 @@ mod tests {
             }),
             aud,
             nonce,
-            SDJWTSerializationFormat::JSON,
+            format.clone(),
         );
 
         assert!(
             result.is_err(),
-            "Verifier accepted JSON presentation with tampered disclosure list",
+            "Verifier accepted {format:?} presentation with tampered disclosure list",
         );
     }
 
@@ -983,7 +1008,7 @@ mod tests {
             ClaimsForSelectiveDisclosureStrategy::AllLevels,
             Some(serde_json::from_str(HOLDER_JWK_KEY_ED25519).unwrap()),
             false,
-            SDJWTSerializationFormat::JSON,
+            SDJWTSerializationFormat::FlattenedJson,
         ).unwrap();
 
         let private_holder_bytes = HOLDER_KEY_ED25519.as_bytes();
@@ -991,7 +1016,7 @@ mod tests {
         let nonce = Some(String::from("testNonce"));
         let aud = Some(String::from("testAud"));
 
-        let presentation = SDJWTHolder::new(sd_jwt, SDJWTSerializationFormat::JSON)
+        let presentation = SDJWTHolder::new(sd_jwt, SDJWTSerializationFormat::FlattenedJson)
             .unwrap()
             .create_presentation(
                 user_claims.as_object().unwrap().clone(),
@@ -1006,7 +1031,7 @@ mod tests {
         // payload. The KB-JWT remains validly signed by the holder key, so
         // signature verification will pass — but the spec requires `iat` to
         // be present, and the verifier must reject this presentation.
-        let mut json: SDJWTJson = serde_json::from_str(&presentation).unwrap();
+        let mut json: SDJWTFlattenedJson = serde_json::from_str(&presentation).unwrap();
         let original_kb_jwt = json.header.kb_jwt.clone().unwrap();
         let kb_parts: Vec<&str> = original_kb_jwt.split('.').collect();
         let payload_bytes = base64url_decode(kb_parts[1]).unwrap();
@@ -1032,7 +1057,7 @@ mod tests {
             }),
             aud,
             nonce,
-            SDJWTSerializationFormat::JSON,
+            SDJWTSerializationFormat::FlattenedJson,
         );
 
         assert!(

--- a/tests/demos.rs
+++ b/tests/demos.rs
@@ -12,7 +12,7 @@ use jsonwebtoken::jwk::Jwk;
 use jsonwebtoken::{DecodingKey, EncodingKey};
 use rstest::{fixture, rstest};
 use sd_jwt_rs::issuer::ClaimsForSelectiveDisclosureStrategy;
-use sd_jwt_rs::{SDJWTHolder, SDJWTIssuer, SDJWTJson, SDJWTVerifier, SDJWTSerializationFormat};
+use sd_jwt_rs::{SDJWTHolder, SDJWTIssuer, SDJWTVerifier, SDJWTFlattenedJson, SDJWTGeneralJson, SDJWTSerializationFormat};
 use sd_jwt_rs::{COMBINED_SERIALIZATION_FORMAT_SEPARATOR, DEFAULT_SIGNING_ALG};
 use serde_json::{json, Map, Value};
 use std::collections::HashSet;
@@ -303,7 +303,7 @@ fn demo_positive_cases(
         Option<EncodingKey>,
         Option<Jwk>,
     ),
-    #[values(SDJWTSerializationFormat::Compact, SDJWTSerializationFormat::JSON)] format: SDJWTSerializationFormat,
+    #[values(SDJWTSerializationFormat::Compact, SDJWTSerializationFormat::FlattenedJson, SDJWTSerializationFormat::GeneralJson)] format: SDJWTSerializationFormat,
     #[values(None, Some(DEFAULT_SIGNING_ALG.to_owned()))] sign_algo: Option<String>,
     #[values(true, false)] add_decoy: bool,
 ) {
@@ -331,46 +331,69 @@ fn demo_positive_cases(
         )
         .unwrap();
 
-    if format == SDJWTSerializationFormat::Compact {
-        let mut issued_parts: HashSet<&str> = issued
-            .split(COMBINED_SERIALIZATION_FORMAT_SEPARATOR)
-            .collect();
-        issued_parts.remove("");
+    match format {
+        SDJWTSerializationFormat::Compact => {
+            let mut issued_parts: HashSet<&str> = issued
+                .split(COMBINED_SERIALIZATION_FORMAT_SEPARATOR)
+                .collect();
+            issued_parts.remove("");
 
-        let mut revealed_parts: HashSet<&str> = presentation
-            .split(COMBINED_SERIALIZATION_FORMAT_SEPARATOR)
-            .collect();
-        revealed_parts.remove("");
+            let mut revealed_parts: HashSet<&str> = presentation
+                .split(COMBINED_SERIALIZATION_FORMAT_SEPARATOR)
+                .collect();
+            revealed_parts.remove("");
 
-        let intersected_parts: HashSet<_> = issued_parts.intersection(&revealed_parts).collect();
-        // Compare that number of disclosed parts are equal
-        let mut revealed_parts_number = revealed_parts.len();
-        if holder_jwk.is_some() {
-            // Remove KB
-            revealed_parts_number -= 1;
+            let intersected_parts: HashSet<_> = issued_parts.intersection(&revealed_parts).collect();
+            // Compare that number of disclosed parts are equal
+            let mut revealed_parts_number = revealed_parts.len();
+            if holder_jwk.is_some() {
+                // Remove KB
+                revealed_parts_number -= 1;
+            }
+            assert_eq!(intersected_parts.len(), revealed_parts_number);
+            // here `+1` means adding issued jwt part also
+            assert_eq!(number_of_revealed_sds + 1, revealed_parts_number);
         }
-        assert_eq!(intersected_parts.len(), revealed_parts_number);
-        // here `+1` means adding issued jwt part also
-        assert_eq!(number_of_revealed_sds + 1, revealed_parts_number);
-    } else {
-        let mut issued: SDJWTJson = serde_json::from_str(&issued).unwrap();
-        let mut revealed: SDJWTJson = serde_json::from_str(&presentation).unwrap();
-        let disclosures: Vec<String> = revealed
-            .header
-            .disclosures
-            .clone()
-            .into_iter()
-            .filter(|d| issued.header.disclosures.contains(d))
-            .collect();
-        assert_eq!(number_of_revealed_sds, disclosures.len());
+        SDJWTSerializationFormat::GeneralJson => {
+            let mut issued: SDJWTGeneralJson = serde_json::from_str(&issued).unwrap();
+            let mut revealed: SDJWTGeneralJson = serde_json::from_str(&presentation).unwrap();
+            let disclosures: Vec<String> = revealed.signatures[0]
+                .header
+                .disclosures
+                .clone()
+                .into_iter()
+                .filter(|d| issued.signatures[0].header.disclosures.contains(d))
+                .collect();
+            assert_eq!(number_of_revealed_sds, disclosures.len());
 
-        if holder_jwk.is_some() {
-            assert!(revealed.header.kb_jwt.is_some());
+            if holder_jwk.is_some() {
+                assert!(revealed.signatures[0].header.kb_jwt.is_some());
+            }
+
+            issued.signatures[0].header.disclosures = disclosures;
+            revealed.signatures[0].header.kb_jwt = None;
+            assert_eq!(revealed, issued);
         }
+        SDJWTSerializationFormat::FlattenedJson => {
+            let mut issued: SDJWTFlattenedJson = serde_json::from_str(&issued).unwrap();
+            let mut revealed: SDJWTFlattenedJson = serde_json::from_str(&presentation).unwrap();
+            let disclosures: Vec<String> = revealed
+                .header
+                .disclosures
+                .clone()
+                .into_iter()
+                .filter(|d| issued.header.disclosures.contains(d))
+                .collect();
+            assert_eq!(number_of_revealed_sds, disclosures.len());
 
-        issued.header.disclosures = disclosures;
-        revealed.header.kb_jwt = None;
-        assert_eq!(revealed, issued);
+            if holder_jwk.is_some() {
+                assert!(revealed.header.kb_jwt.is_some());
+            }
+
+            issued.header.disclosures = disclosures;
+            revealed.header.kb_jwt = None;
+            assert_eq!(revealed, issued);
+        }
     }
 
     // Verify presentation


### PR DESCRIPTION
## Problem

RFC 9901 §8 defines two JWS JSON Serializations: Flattened (§8.2) and General
(§8.3). The crate supported the Compact serialization (§4) and the Flattened JSON
serialization, but (a) not the General JSON serialization (the
`{"payload", "signatures": [...]}` envelope), and (b) exposed the Flattened variant
under the ambiguous name `SDJWTSerializationFormat::JSON`.

This addresses #42 (align the JWS JSON Serialization with the spec's updated,
header-nested structure). #56 already brought the Flattened serialization in line
(§8.1 new unprotected header parameters + §8.2); this PR completes §8 by adding the
General serialization (§8.3).

## Change

Add `SDJWTSerializationFormat::GeneralJson` so an SD-JWT / SD-JWT+KB can be issued,
presented, and verified using the General JSON Serialization:

```json
{
  "payload": "...",
  "signatures": [
    { "protected": "...", "signature": "...", "header": { "disclosures": ["...", "..."], "kb_jwt": "..." } }
  ]
}
```

- New public types `SDJWTGeneralJson` / `SDJWTGeneralJsonSignature` mirror the
  visibility of `SDJWTFlattenedJson` (raw JWS members private; `signatures` and
  each `header` public).
- Per §8.3, the Disclosures and the optional `kb_jwt` are written into, and read
  from, the first signature's unprotected header.
- Parsing reconstructs the compact form from `signatures[0]` and reuses the existing
  verification path, so verification is identical across formats.

## Breaking change

For symmetry and clarity the existing Flattened serialization is renamed:
`SDJWTSerializationFormat::JSON` → `FlattenedJson`, and the `SDJWTJson` struct →
`SDJWTFlattenedJson`. Both have always produced the Flattened JWS JSON Serialization
(§8.2 — a single top-level signature); the bare name `JSON` became ambiguous next to
the new General serialization. The formats and their structs now map 1:1 to the spec:

| `SDJWTSerializationFormat` | struct | format | spec |
|---|---|---|---|
| `Compact` | — | Compact Serialization | §4 |
| `FlattenedJson` | `SDJWTFlattenedJson` | Flattened JWS JSON Serialization | §8.2 |
| `GeneralJson` | `SDJWTGeneralJson` | General JWS JSON Serialization | §8.3 |

Migration: replace `SDJWTSerializationFormat::JSON` with `FlattenedJson`, and the
`SDJWTJson` struct with `SDJWTFlattenedJson`.

**Scope:** the General envelope wraps a single issuer signature. Genuine
multiple-issuer signing and per-signature key-set verification are out of scope
(neither the linked sd-jwt-python nor sd-jwt-js performs per-signature key-set
verification today — both operate on `signatures[0]`).

## Test

- `demo_positive_cases` runs every claim structure (flat, nested, recursive,
  arrayed, complex eIDAS, W3C VC) across all three formats (Compact, FlattenedJson,
  GeneralJson), asserting per-format disclosure round-trip and full struct equality.
- `test_parse_general_json_rejects_empty_signatures` — a General JSON with an empty
  `signatures` array is rejected explicitly (serde accepts `[]`, so the parser guards
  against it rather than panicking on `signatures[0]`).
- `reject_tampered_presentation_with_injected_disclosure` (rstest, cases `compact` /
  `flattened` / `general`) — an extra Disclosure injected into the presentation (a
  `~`-segment before the KB-JWT for §4, a top-level `header` for §8.2, the first
  signature's header for §8.3) is rejected because the KB-JWT's `sd_hash` no longer
  matches.
- Full suite green: 220 (27 lib + 192 integration + 1 doc). No new clippy warnings.

## RFC 9901 §8.3, General JSON Serialization (verbatim)

> In the case of General JSON Serialization, there are multiple unprotected
> headers (one per signature). If present, disclosures and kb_jwt MUST be
> included in the first unprotected header and MUST NOT be present in any
> following unprotected headers.

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)
