### PR TITLE
RFC 9901 §7.1: reject malformed Disclosures (wrong element count)

### DIFF
--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -378,6 +378,12 @@ impl SDJWTVerifier {
                         .ok_or(Error::InvalidArrayDisclosureObject(
                             value_for_digest.to_string(),
                         ))?;
+                if disclosure.len() != 3 {
+                    return Err(Error::InvalidDisclosure(format!(
+                        "Object-property Disclosure must be a 3-element array [salt, name, value]: {}",
+                        value_for_digest
+                    )));
+                }
                 let key = disclosure[1]
                     .as_str()
                     .ok_or(Error::ConversionError("str".to_string()))?
@@ -417,6 +423,12 @@ impl SDJWTVerifier {
                     .ok_or(Error::InvalidArrayDisclosureObject(
                         value_for_digest.to_string(),
                     ))?;
+            if disclosure.len() != 2 {
+                return Err(Error::InvalidArrayDisclosureObject(format!(
+                    "Array-element Disclosure must be a 2-element array [salt, value]: {}",
+                    value_for_digest
+                )));
+            }
 
             let value = disclosure[1].clone();
             let unpacked_value = self.unpack_disclosed_claims(&value)?;
@@ -1252,5 +1264,69 @@ mod tests {
                 "expected an expiry failure, got: {err}"
             ),
         }
+    }
+
+    #[test]
+    fn reject_object_property_disclosure_with_wrong_element_count() {
+        use crate::utils::base64_hash;
+        // A conforming object-property Disclosure is a 3-element array
+        // [salt, claim name, claim value]. Craft a malformed 2-element one
+        // and reference its digest from the signed `_sd` array.
+        let malformed = base64url_encode(br#"["salt", "valuewithoutname"]"#);
+        let digest = base64_hash(malformed.as_bytes());
+        let payload = json!({
+            "iss": "https://example.com/issuer",
+            "iat": 1683000000,
+            "_sd": [digest],
+            "_sd_alg": "sha-256",
+        });
+        let issuer_key = EncodingKey::from_ec_pem(PRIVATE_ISSUER_PEM.as_bytes()).unwrap();
+        let signed =
+            jsonwebtoken::encode(&Header::new(Algorithm::ES256), &payload, &issuer_key).unwrap();
+        let sd_jwt = format!("{signed}~{malformed}~");
+
+        let result = SDJWTVerifier::new(
+            sd_jwt,
+            Box::new(|_, _| DecodingKey::from_ec_pem(PUBLIC_ISSUER_PEM.as_bytes()).unwrap()),
+            None,
+            None,
+            SDJWTSerializationFormat::Compact,
+        );
+        assert!(
+            result.is_err(),
+            "verifier accepted a malformed (non-3-element) object-property Disclosure",
+        );
+    }
+
+    #[test]
+    fn reject_array_element_disclosure_with_wrong_element_count() {
+        use crate::utils::base64_hash;
+        // A conforming array-element Disclosure is a 2-element array
+        // [salt, value]. Craft a malformed 3-element one and reference it
+        // via {"...": digest}.
+        let malformed = base64url_encode(br#"["salt", "claimname", "value"]"#);
+        let digest = base64_hash(malformed.as_bytes());
+        let payload = json!({
+            "iss": "https://example.com/issuer",
+            "iat": 1683000000,
+            "arr": [ { "...": digest } ],
+            "_sd_alg": "sha-256",
+        });
+        let issuer_key = EncodingKey::from_ec_pem(PRIVATE_ISSUER_PEM.as_bytes()).unwrap();
+        let signed =
+            jsonwebtoken::encode(&Header::new(Algorithm::ES256), &payload, &issuer_key).unwrap();
+        let sd_jwt = format!("{signed}~{malformed}~");
+
+        let result = SDJWTVerifier::new(
+            sd_jwt,
+            Box::new(|_, _| DecodingKey::from_ec_pem(PUBLIC_ISSUER_PEM.as_bytes()).unwrap()),
+            None,
+            None,
+            SDJWTSerializationFormat::Compact,
+        );
+        assert!(
+            result.is_err(),
+            "verifier accepted a malformed (non-2-element) array-element Disclosure",
+        );
     }
 }


### PR DESCRIPTION
## Problem

RFC 9901 §7.1 requires the Verifier to reject a Disclosure whose decoded array
does not have the expected number of elements:

> If the contents of the respective Disclosure is not a JSON array of three elements (salt, claim name, claim value), the SD-JWT MUST be rejected.

> If the contents of the respective Disclosure is not a JSON array of two elements (salt, value), the SD-JWT MUST be rejected.

The recursive unpack indexed `disclosure[1]`/`disclosure[2]` without checking
the length. A two-element Disclosure referenced from `_sd` therefore panicked
with an index-out-of-bounds, and a three-element Disclosure referenced as an
array element was silently mis-unpacked (the claim name was inserted as the
array value).

## Change

Both unpack paths now validate the element count — exactly three
`[salt, claim name, claim value]` for an object property referenced from `_sd`,
exactly two `[salt, value]` for an array element referenced via a
`{"...": digest}` object — and return an error instead of panicking or
mis-unpacking.

## Test

- `reject_object_property_disclosure_with_wrong_element_count`: a crafted
  2-element Disclosure referenced from the signed `_sd` array is rejected
  (previously a panic).
- `reject_array_element_disclosure_with_wrong_element_count`: a crafted
  3-element Disclosure referenced as an array element is rejected (previously
  mis-unpacked).
- Full suite green: 223 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
