### PR TITLE
RFC 9901 §7.1: validate `nbf` when present

### DIFF
--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -120,6 +120,9 @@ impl SDJWTVerifier {
         // RFC 9901 §4.1: `exp` is not mandated, so don't require it. `validate_exp`
         // stays true, so a present `exp` is still checked for expiry.
         validation.required_spec_claims.remove("exp");
+        // `nbf` is optional too (not added to required_spec_claims), but when
+        // present it must be honored; jsonwebtoken leaves `validate_nbf` off.
+        validation.validate_nbf = true;
         let claims = jsonwebtoken::decode(
             sd_jwt,
             &issuer_public_key,
@@ -1107,6 +1110,61 @@ mod tests {
             result.is_err(),
             "Verifier accepted KB-JWT presentation missing required `iat` claim",
         );
+    }
+
+    #[test]
+    fn reject_sd_jwt_with_future_nbf() {
+        // An SD-JWT whose `nbf` is in the future is not yet valid.
+        let payload = json!({
+            "iss": "https://example.com/issuer",
+            "iat": 1683000000,
+            "nbf": 1883000000,
+            "address": { "country": "DE" }
+        });
+        let issuer_key = EncodingKey::from_ec_pem(PRIVATE_ISSUER_PEM.as_bytes()).unwrap();
+        let signed =
+            jsonwebtoken::encode(&Header::new(Algorithm::ES256), &payload, &issuer_key).unwrap();
+        let sd_jwt = format!("{signed}~");
+
+        let result = SDJWTVerifier::new(
+            sd_jwt,
+            Box::new(|_, _| DecodingKey::from_ec_pem(PUBLIC_ISSUER_PEM.as_bytes()).unwrap()),
+            None,
+            None,
+            SDJWTSerializationFormat::Compact,
+        );
+        match result {
+            Ok(_) => panic!("verifier accepted a presentation with a future `nbf`"),
+            Err(err) => assert!(
+                err.to_string().contains("ImmatureSignature"),
+                "expected an immature-signature failure, got: {err}"
+            ),
+        }
+    }
+
+    #[test]
+    fn verify_presentation_with_past_nbf() {
+        // A present `nbf` already in the past must not block verification.
+        let user_claims = json!({
+            "iss": "https://example.com/issuer",
+            "iat": 1683000000,
+            "nbf": 1683000000,
+            "address": { "country": "DE" }
+        });
+        let issuer_key = EncodingKey::from_ec_pem(PRIVATE_ISSUER_PEM.as_bytes()).unwrap();
+        let signed =
+            jsonwebtoken::encode(&Header::new(Algorithm::ES256), &user_claims, &issuer_key)
+                .unwrap();
+        let sd_jwt = format!("{signed}~");
+
+        let result = SDJWTVerifier::new(
+            sd_jwt,
+            Box::new(|_, _| DecodingKey::from_ec_pem(PUBLIC_ISSUER_PEM.as_bytes()).unwrap()),
+            None,
+            None,
+            SDJWTSerializationFormat::Compact,
+        );
+        assert!(result.is_ok(), "verifier rejected an SD-JWT with a past `nbf`");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

RFC 9901 §7.1 has the Verifier check temporal validity claims:

> Check that the SD-JWT is valid using claims such as `nbf`, `exp`, and `aud` in the processed payload, if present.

The Issuer-signed JWT was decoded with jsonwebtoken's default `Validation`,
which validates `exp` but leaves `validate_nbf` off, so an SD-JWT with a future
`nbf` was accepted as valid.

## Change

The Verifier's Issuer-JWT validation now enables `validate_nbf`. `nbf` is not
added to `required_spec_claims`, so it stays optional — an absent `nbf` still
verifies, and a present `nbf` in the future is rejected as immature.

## Test

- `reject_sd_jwt_with_future_nbf`: an SD-JWT whose `nbf` lies in the future is
  rejected.
- `verify_presentation_with_past_nbf`: a past `nbf` still verifies.
- Full suite green: 223 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
