### PR TITLE
RFC 9901 §7.2: Holder-side Issuer-signature verification [breaking]

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ fn demo() {
     let mut issuer = SDJWTIssuer::new(issuer_key, None);
     let sd_jwt = issuer.issue_sd_jwt(claims, ClaimsForSelectiveDisclosureStrategy::AllLevels, holder_key, add_decoy, SDJWTSerializationFormat::Compact).unwrap();
 
-    let mut holder = SDJWTHolder::new(sd_jwt, SDJWTSerializationFormat::Compact).unwrap();
+    let mut holder = SDJWTHolder::new(sd_jwt, SDJWTSerializationFormat::Compact, Box::new(cb_to_resolve_issuer_key)).unwrap();
     let presentation = holder.create_presentation(claims_to_disclosure, None, None, None, None).unwrap();
 
-    let verified_claims = SDJWTVerifier::new(presentation, cb_to_resolve_issuer_key, None, None, SDJWTSerializationFormat::Compact).unwrap()
+    let verified_claims = SDJWTVerifier::new(presentation, Box::new(cb_to_resolve_issuer_key), None, None, SDJWTSerializationFormat::Compact).unwrap()
                             .verified_claims;
 }
 ```

--- a/generate/src/main.rs
+++ b/generate/src/main.rs
@@ -81,7 +81,7 @@ fn generate_and_check(
     };
 
     let sd_jwt = issue_sd_jwt(directory, &specs, settings, serialization_format.clone(), decoy)?;
-    let presentation = create_presentation(&sd_jwt, serialization_format.clone(), &specs.holder_disclosed_claims)?;
+    let presentation = create_presentation(directory, &sd_jwt, serialization_format.clone(), &specs.holder_disclosed_claims)?;
 
     // Verify presentation
     let verified_claims = verify_presentation(directory, &presentation, serialization_format.clone())?;
@@ -152,11 +152,21 @@ fn issue_sd_jwt(
 }
 
 fn create_presentation(
+    directory: &PathBuf,
     sd_jwt: &str,
     serialization_format: SDJWTSerializationFormat,
     disclosed_claims: &serde_json::Map<String, serde_json::Value>
 ) -> Result<String> {
-    let mut holder = SDJWTHolder::new(sd_jwt.to_string(), serialization_format).unwrap();
+    let pub_key_path = directory.clone().join(ISSUER_PUBLIC_KEY_PEM_FILE_NAME);
+    let mut holder = SDJWTHolder::new(
+        sd_jwt.to_string(),
+        serialization_format,
+        Box::new(move |_, _| {
+            let key = std::fs::read(&pub_key_path).expect("Failed to read file");
+            DecodingKey::from_ec_pem(&key).expect("Unable to create DecodingKey")
+        }),
+    )
+    .unwrap();
 
     let presentation = holder
         .create_presentation(

--- a/src/holder.rs
+++ b/src/holder.rs
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    error, SDJWTFlattenedJson, SDJWTGeneralJson, SDJWTGeneralJsonSignature, SDJWTSerializationFormat,
-    SDJWTUnprotectedHeader,
+    error, KeyResolver, SDJWTFlattenedJson, SDJWTGeneralJson, SDJWTGeneralJsonSignature,
+    SDJWTSerializationFormat, SDJWTUnprotectedHeader,
 };
 use error::{Error, Result};
 use jsonwebtoken::{Algorithm, EncodingKey, Header};
@@ -37,6 +37,7 @@ impl SDJWTHolder {
     /// # Arguments
     /// * `sd_jwt_with_disclosures` - SD JWT with disclosures in the format specified by `serialization_format`
     /// * `serialization_format` - Serialization format of the SD JWT, see [SDJWTSerializationFormat].
+    /// * `cb_get_issuer_key` - Callback returning the Issuer's public key, used to verify the Issuer signature. Use [`SDJWTHolder::new_unverified`] to skip verification.
     ///
     /// # Returns
     /// * `SDJWTHolder` - Instance of SDJWTHolder
@@ -45,7 +46,40 @@ impl SDJWTHolder {
     /// * `InvalidInput` - If the serialization format is not supported
     /// * `InvalidState` - If the SD JWT data is not valid
     /// * `DeserializationError` - If the SD JWT serialization is not valid
-    pub fn new(sd_jwt_with_disclosures: String, serialization_format: SDJWTSerializationFormat) -> Result<Self> {
+    pub fn new(
+        sd_jwt_with_disclosures: String,
+        serialization_format: SDJWTSerializationFormat,
+        cb_get_issuer_key: Box<KeyResolver>,
+    ) -> Result<Self> {
+        Self::build(sd_jwt_with_disclosures, serialization_format, Some(cb_get_issuer_key))
+    }
+
+    /// Like [`SDJWTHolder::new`], but skips Issuer-signature verification —
+    /// for inputs already verified out of band or for test fixtures.
+    ///
+    /// # Arguments
+    /// * `sd_jwt_with_disclosures` - SD JWT with disclosures in the format specified by `serialization_format`
+    /// * `serialization_format` - Serialization format of the SD JWT, see [SDJWTSerializationFormat].
+    ///
+    /// # Returns
+    /// * `SDJWTHolder` - Instance of SDJWTHolder
+    ///
+    /// # Errors
+    /// * `InvalidInput` - If the serialization format is not supported
+    /// * `InvalidState` - If the SD JWT data is not valid
+    /// * `DeserializationError` - If the SD JWT serialization is not valid
+    pub fn new_unverified(
+        sd_jwt_with_disclosures: String,
+        serialization_format: SDJWTSerializationFormat,
+    ) -> Result<Self> {
+        Self::build(sd_jwt_with_disclosures, serialization_format, None)
+    }
+
+    fn build(
+        sd_jwt_with_disclosures: String,
+        serialization_format: SDJWTSerializationFormat,
+        cb_get_issuer_key: Option<Box<KeyResolver>>,
+    ) -> Result<Self> {
         let mut holder = SDJWTHolder {
             sd_jwt_engine: SDJWTCommon {
                 serialization_format,
@@ -74,7 +108,27 @@ impl SDJWTHolder {
             ));
         }
 
-        //TODO Verify signature before accepting the JWT
+        if let Some(cb_get_issuer_key) = cb_get_issuer_key {
+            let engine = &holder.sd_jwt_engine;
+            let sd_jwt = engine
+                .unverified_sd_jwt
+                .as_ref()
+                .ok_or(Error::InvalidState("Cannot reference jwt".to_string()))?;
+            let header = jsonwebtoken::decode_header(sd_jwt)
+                .map_err(|e| Error::DeserializationError(e.to_string()))?;
+            let unverified_issuer = engine
+                .unverified_input_sd_jwt_payload
+                .as_ref()
+                .ok_or(Error::InvalidState("Cannot reference payload".to_string()))?
+                .get("iss")
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    Error::InvalidInput("Issuer-signed JWT is missing `iss`".to_string())
+                })?;
+            let key = cb_get_issuer_key(unverified_issuer, &header);
+            engine.verify_signature(&key)?;
+        }
+
         holder.sd_jwt_payload = holder
             .sd_jwt_engine
             .unverified_input_sd_jwt_payload
@@ -377,12 +431,195 @@ impl SDJWTHolder {
 #[cfg(test)]
 mod tests {
     use crate::issuer::ClaimsForSelectiveDisclosureStrategy;
-    use crate::{SDJWTHolder, SDJWTIssuer, COMBINED_SERIALIZATION_FORMAT_SEPARATOR, SDJWTSerializationFormat};
-    use jsonwebtoken::EncodingKey;
+    use crate::{SDJWTHolder, SDJWTIssuer, SDJWTSerializationFormat, COMBINED_SERIALIZATION_FORMAT_SEPARATOR};
+    use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header};
     use serde_json::{json, Map, Value};
     use std::collections::HashSet;
 
     const PRIVATE_ISSUER_PEM: &str = "-----BEGIN PRIVATE KEY-----\nMIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgUr2bNKuBPOrAaxsR\nnbSH6hIhmNTxSGXshDSUD1a1y7ihRANCAARvbx3gzBkyPDz7TQIbjF+ef1IsxUwz\nX1KWpmlVv+421F7+c1sLqGk4HUuoVeN8iOoAcE547pJhUEJyf5Asc6pP\n-----END PRIVATE KEY-----\n";
+    const PUBLIC_ISSUER_PEM: &str = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEb28d4MwZMjw8+00CG4xfnn9SLMVM\nM19SlqZpVb/uNtRe/nNbC6hpOB1LqFXjfIjqAHBOeO6SYVBCcn+QLHOqTw==\n-----END PUBLIC KEY-----\n";
+
+    fn issuer_key_resolver() -> Box<crate::KeyResolver> {
+        Box::new(|_iss: &str, _hdr: &jsonwebtoken::Header| {
+            DecodingKey::from_ec_pem(PUBLIC_ISSUER_PEM.as_bytes()).unwrap()
+        })
+    }
+
+    #[test]
+    fn new_accepts_valid_signature() {
+        let user_claims = json!({
+            "sub": "6c5c0a49-b589-431d-bae7-219122a9ec2c",
+            "iss": "https://example.com/issuer",
+            "iat": 1683000000,
+            "exp": 1883000000,
+            "address": { "country": "DE" }
+        });
+        let issuer_key = EncodingKey::from_ec_pem(PRIVATE_ISSUER_PEM.as_bytes()).unwrap();
+        let sd_jwt = SDJWTIssuer::new(issuer_key, None)
+            .issue_sd_jwt(
+                user_claims.clone(),
+                ClaimsForSelectiveDisclosureStrategy::AllLevels,
+                None,
+                false,
+                SDJWTSerializationFormat::Compact,
+            )
+            .unwrap();
+
+        let holder = SDJWTHolder::new(
+            sd_jwt,
+            SDJWTSerializationFormat::Compact,
+            issuer_key_resolver(),
+        );
+        assert!(holder.is_ok());
+    }
+
+    #[test]
+    fn new_rejects_tampered_signature() {
+        let user_claims = json!({
+            "sub": "6c5c0a49-b589-431d-bae7-219122a9ec2c",
+            "iss": "https://example.com/issuer",
+            "iat": 1683000000,
+            "exp": 1883000000,
+            "address": { "country": "DE" }
+        });
+        let issuer_key = EncodingKey::from_ec_pem(PRIVATE_ISSUER_PEM.as_bytes()).unwrap();
+        let sd_jwt = SDJWTIssuer::new(issuer_key, None)
+            .issue_sd_jwt(
+                user_claims,
+                ClaimsForSelectiveDisclosureStrategy::AllLevels,
+                None,
+                false,
+                SDJWTSerializationFormat::Compact,
+            )
+            .unwrap();
+
+        // Corrupt the first character of the JWT signature segment. A leading
+        // base64url character maps to full signature bytes, so this yields a
+        // well-formed but cryptographically invalid signature and exercises the
+        // ECDSA rejection path — unlike flipping the trailing character, whose
+        // spare bits can fail base64 decoding before verification is reached.
+        let parts: Vec<&str> = sd_jwt.split('~').collect();
+        let jwt_pieces: Vec<&str> = parts[0].split('.').collect();
+        let mut sig: Vec<char> = jwt_pieces[2].chars().collect();
+        sig[0] = if sig[0] == 'A' { 'B' } else { 'A' };
+        let sig: String = sig.into_iter().collect();
+        let tampered_jwt = format!("{}.{}.{}", jwt_pieces[0], jwt_pieces[1], sig);
+        let tampered = std::iter::once(tampered_jwt.as_str())
+            .chain(parts.iter().skip(1).copied())
+            .collect::<Vec<_>>()
+            .join("~");
+
+        let result = SDJWTHolder::new(
+            tampered,
+            SDJWTSerializationFormat::Compact,
+            issuer_key_resolver(),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn new_unverified_accepts_tampered_signature() {
+        // `new_unverified` is the explicit opt-out of Issuer-signature
+        // verification, for inputs already verified out of band or for test
+        // fixtures: an SD-JWT whose signature would not verify is accepted.
+        let user_claims = json!({
+            "sub": "6c5c0a49-b589-431d-bae7-219122a9ec2c",
+            "iss": "https://example.com/issuer",
+            "iat": 1683000000,
+            "exp": 1883000000,
+            "address": { "country": "DE" }
+        });
+        let issuer_key = EncodingKey::from_ec_pem(PRIVATE_ISSUER_PEM.as_bytes()).unwrap();
+        let sd_jwt = SDJWTIssuer::new(issuer_key, None)
+            .issue_sd_jwt(
+                user_claims,
+                ClaimsForSelectiveDisclosureStrategy::AllLevels,
+                None,
+                false,
+                SDJWTSerializationFormat::Compact,
+            )
+            .unwrap();
+
+        let parts: Vec<&str> = sd_jwt.split('~').collect();
+        let jwt_pieces: Vec<&str> = parts[0].split('.').collect();
+        let mut sig: Vec<char> = jwt_pieces[2].chars().collect();
+        sig[0] = if sig[0] == 'A' { 'B' } else { 'A' };
+        let sig: String = sig.into_iter().collect();
+        let tampered_jwt = format!("{}.{}.{}", jwt_pieces[0], jwt_pieces[1], sig);
+        let tampered = std::iter::once(tampered_jwt.as_str())
+            .chain(parts.iter().skip(1).copied())
+            .collect::<Vec<_>>()
+            .join("~");
+
+        let result = SDJWTHolder::new_unverified(tampered, SDJWTSerializationFormat::Compact);
+        assert!(
+            result.is_ok(),
+            "new_unverified must accept an SD-JWT without verifying its signature",
+        );
+    }
+
+    #[test]
+    fn new_accepts_issuer_jwt_with_aud() {
+        // An Issuer-signed JWT may legitimately carry an `aud` claim; the Holder's
+        // signature check must accept it rather than reject it for lack of an
+        // expected audience. NoSDClaims keeps `aud` as a plaintext top-level claim.
+        let user_claims = json!({
+            "sub": "6c5c0a49-b589-431d-bae7-219122a9ec2c",
+            "iss": "https://example.com/issuer",
+            "iat": 1683000000,
+            "exp": 1883000000,
+            "aud": "https://verifier.example.com",
+            "address": { "country": "DE" }
+        });
+        let issuer_key = EncodingKey::from_ec_pem(PRIVATE_ISSUER_PEM.as_bytes()).unwrap();
+        let sd_jwt = SDJWTIssuer::new(issuer_key, None)
+            .issue_sd_jwt(
+                user_claims,
+                ClaimsForSelectiveDisclosureStrategy::NoSDClaims,
+                None,
+                false,
+                SDJWTSerializationFormat::Compact,
+            )
+            .unwrap();
+
+        let holder = SDJWTHolder::new(
+            sd_jwt,
+            SDJWTSerializationFormat::Compact,
+            issuer_key_resolver(),
+        );
+        assert!(
+            holder.is_ok(),
+            "Holder rejected a validly-signed Issuer JWT carrying an `aud` claim",
+        );
+    }
+
+    #[test]
+    fn new_rejects_issuer_jwt_with_future_nbf() {
+        // An SD-JWT whose `nbf` is in the future is not yet valid.
+        let payload = json!({
+            "iss": "https://example.com/issuer",
+            "iat": 1683000000,
+            "nbf": 1883000000,
+            "address": { "country": "DE" }
+        });
+        let issuer_key = EncodingKey::from_ec_pem(PRIVATE_ISSUER_PEM.as_bytes()).unwrap();
+        let signed =
+            jsonwebtoken::encode(&Header::new(Algorithm::ES256), &payload, &issuer_key).unwrap();
+        let sd_jwt = format!("{signed}~");
+
+        let result = SDJWTHolder::new(
+            sd_jwt,
+            SDJWTSerializationFormat::Compact,
+            issuer_key_resolver(),
+        );
+        match result {
+            Ok(_) => panic!("holder accepted an SD-JWT with a future `nbf`"),
+            Err(err) => assert!(
+                err.to_string().contains("ImmatureSignature"),
+                "expected an immature-signature failure, got: {err}"
+            ),
+        }
+    }
 
     #[test]
     fn new_rejects_sd_jwt_with_key_binding() {
@@ -409,7 +646,7 @@ mod tests {
         assert!(sd_jwt.ends_with(COMBINED_SERIALIZATION_FORMAT_SEPARATOR));
         let sd_jwt_kb = format!("{sd_jwt}fakekbjwt");
 
-        let result = SDJWTHolder::new(sd_jwt_kb, SDJWTSerializationFormat::Compact);
+        let result = SDJWTHolder::new_unverified(sd_jwt_kb, SDJWTSerializationFormat::Compact);
         assert!(
             result.is_err(),
             "Holder accepted an SD-JWT that already carried a Key Binding JWT",
@@ -443,6 +680,7 @@ mod tests {
         let presentation = SDJWTHolder::new(
             sd_jwt.clone(),
             SDJWTSerializationFormat::Compact,
+            issuer_key_resolver(),
         )
             .unwrap()
             .create_presentation(
@@ -483,7 +721,7 @@ mod tests {
         let issued = sd_jwt.clone();
         user_claims["address"] = Value::Object(Map::new());
         let presentation =
-            SDJWTHolder::new(sd_jwt, SDJWTSerializationFormat::Compact)
+            SDJWTHolder::new(sd_jwt, SDJWTSerializationFormat::Compact, issuer_key_resolver())
                 .unwrap()
                 .create_presentation(
                     user_claims.as_object().unwrap().clone(),
@@ -555,7 +793,7 @@ mod tests {
         let issued = sd_jwt.clone();
         println!("{}", issued);
         let presentation =
-            SDJWTHolder::new(sd_jwt, SDJWTSerializationFormat::Compact)
+            SDJWTHolder::new_unverified(sd_jwt, SDJWTSerializationFormat::Compact)
                 .unwrap()
                 .create_presentation(
                     user_claims.as_object().unwrap().clone(),
@@ -676,7 +914,7 @@ mod tests {
         );
 
         let presentation =
-            SDJWTHolder::new(sd_jwt, SDJWTSerializationFormat::Compact)
+            SDJWTHolder::new_unverified(sd_jwt, SDJWTSerializationFormat::Compact)
                 .unwrap()
                 .create_presentation(
                     revealed.as_object().unwrap().clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,11 +6,15 @@ use crate::error::Error;
 use crate::utils::{base64_hash, base64url_decode, jwt_payload_decode};
 
 use error::Result;
+use jsonwebtoken::{Algorithm, DecodingKey, Header, Validation};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use strum::Display;
 use std::collections::HashMap;
+use std::str::FromStr;
 pub use {holder::SDJWTHolder, issuer::SDJWTIssuer, issuer::ClaimsForSelectiveDisclosureStrategy, verifier::SDJWTVerifier};
+
+pub type KeyResolver = dyn Fn(&str, &Header) -> DecodingKey;
 
 mod disclosure;
 pub mod error;
@@ -93,6 +97,35 @@ pub struct SDJWTUnprotectedHeader {
 
 // Define the SDJWTCommon struct to hold common properties.
 impl SDJWTCommon {
+    fn verify_signature(&self, key: &DecodingKey) -> Result<()> {
+        let sd_jwt = self
+            .unverified_sd_jwt
+            .as_ref()
+            .ok_or(Error::InvalidState("Cannot reference jwt".to_string()))?;
+        let alg_str = self.sign_alg.as_deref().ok_or_else(|| {
+            Error::InvalidInput(
+                "Issuer-signed JWT header is missing the `alg` parameter".to_string(),
+            )
+        })?;
+        let algorithm =
+            Algorithm::from_str(alg_str).map_err(|e| Error::DeserializationError(e.to_string()))?;
+        let mut validation = Validation::new(algorithm);
+        // RFC 9901 §4.1: `exp` is not mandated, so don't require it. `validate_exp`
+        // stays true, so a present `exp` is still checked for expiry.
+        validation.required_spec_claims.remove("exp");
+        // `nbf` is optional too (not added to required_spec_claims), but when
+        // present it must be honored; jsonwebtoken leaves `validate_nbf` off.
+        validation.validate_nbf = true;
+        // A present `aud` in the Issuer-signed JWT is the Issuer's audience, not one
+        // the Holder validates here; jsonwebtoken rejects a present `aud` when no
+        // expected audience is set, so disable that check for the signature step.
+        validation.validate_aud = false;
+        jsonwebtoken::decode::<Map<String, Value>>(sd_jwt, key, &validation).map_err(|e| {
+            Error::DeserializationError(format!("Issuer signature verification failed: {}", e))
+        })?;
+        Ok(())
+    }
+
     fn create_hash_mappings(&mut self) -> Result<()> {
         self.hash_to_decoded_disclosure = HashMap::new();
         self.hash_to_disclosure = HashMap::new();

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -6,7 +6,7 @@ use crate::SDJWTSerializationFormat;
 use crate::error::Error;
 use crate::error::Result;
 use jsonwebtoken::jwk::Jwk;
-use jsonwebtoken::{Algorithm, DecodingKey, Header, Validation};
+use jsonwebtoken::{Algorithm, DecodingKey, Validation};
 use log::debug;
 use serde_json::{Map, Value};
 use std::ops::Add;
@@ -17,12 +17,10 @@ use std::vec::Vec;
 
 use crate::utils::base64_hash;
 use crate::{
-    SDJWTCommon, CNF_KEY, COMBINED_SERIALIZATION_FORMAT_SEPARATOR, DEFAULT_DIGEST_ALG,
+    SDJWTCommon, KeyResolver, CNF_KEY, COMBINED_SERIALIZATION_FORMAT_SEPARATOR, DEFAULT_DIGEST_ALG,
     DEFAULT_SIGNING_ALG, DIGEST_ALG_KEY, JWK_KEY, KB_DIGEST_KEY, KB_JWT_TYP_HEADER, SD_DIGESTS_KEY,
     SD_LIST_PREFIX,
 };
-
-type KeyResolver = dyn Fn(&str, &Header) -> DecodingKey;
 
 pub struct SDJWTVerifier {
     sd_jwt_engine: SDJWTCommon,
@@ -529,7 +527,11 @@ mod tests {
             SDJWTSerializationFormat::Compact,
         )
             .unwrap();
-        let presentation = SDJWTHolder::new(sd_jwt.clone(), SDJWTSerializationFormat::Compact)
+        let presentation = SDJWTHolder::new(
+            sd_jwt.clone(),
+            SDJWTSerializationFormat::Compact,
+            Box::new(|_, _| DecodingKey::from_ec_pem(PUBLIC_ISSUER_PEM.as_bytes()).unwrap()),
+        )
             .unwrap()
             .create_presentation(
                 user_claims.as_object().unwrap().clone(),
@@ -580,7 +582,7 @@ mod tests {
         )
             .unwrap();
 
-        let presentation = SDJWTHolder::new(sd_jwt.clone(), SDJWTSerializationFormat::Compact)
+        let presentation = SDJWTHolder::new_unverified(sd_jwt.clone(), SDJWTSerializationFormat::Compact)
             .unwrap()
             .create_presentation(
                 user_claims.as_object().unwrap().clone(),
@@ -656,7 +658,7 @@ mod tests {
         claims_to_disclose["addresses"] = Value::Array(vec![Value::Bool(true), Value::Bool(true)]);
         claims_to_disclose["nationalities"] =
             Value::Array(vec![Value::Bool(true), Value::Bool(true)]);
-        let presentation = SDJWTHolder::new(sd_jwt, SDJWTSerializationFormat::Compact)
+        let presentation = SDJWTHolder::new_unverified(sd_jwt, SDJWTSerializationFormat::Compact)
             .unwrap()
             .create_presentation(
                 claims_to_disclose.as_object().unwrap().clone(),
@@ -751,7 +753,7 @@ mod tests {
 
         let claims_to_disclose = json!({});
 
-        let presentation = SDJWTHolder::new(sd_jwt, SDJWTSerializationFormat::Compact)
+        let presentation = SDJWTHolder::new_unverified(sd_jwt, SDJWTSerializationFormat::Compact)
             .unwrap()
             .create_presentation(
                 claims_to_disclose.as_object().unwrap().clone(),
@@ -817,7 +819,11 @@ mod tests {
         )
             .unwrap();
        
-        let presentation = SDJWTHolder::new(sd_jwt.clone(), SDJWTSerializationFormat::FlattenedJson) // Changed to Flattened Json format
+        let presentation = SDJWTHolder::new(
+            sd_jwt.clone(),
+            SDJWTSerializationFormat::FlattenedJson, // Changed to Flattened Json format
+            Box::new(|_, _| DecodingKey::from_ed_pem(PUBLIC_ISSUER_ED25519_PEM.as_bytes()).unwrap()),
+        )
             .unwrap()
             .create_presentation(
                 user_claims.as_object().unwrap().clone(),
@@ -878,7 +884,7 @@ mod tests {
         let nonce = Some(String::from("testNonce"));
         let aud = Some(String::from("testAud"));
 
-        let mut holder = SDJWTHolder::new(sd_jwt.clone(), SDJWTSerializationFormat::FlattenedJson).unwrap(); // Changed to Flattened Json format
+        let mut holder = SDJWTHolder::new_unverified(sd_jwt.clone(), SDJWTSerializationFormat::FlattenedJson).unwrap(); // Changed to Flattened Json format
         let presentation = holder.create_presentation(
                 user_claims.as_object().unwrap().clone(),
                 nonce.clone(),
@@ -950,7 +956,7 @@ mod tests {
         let nonce = Some(String::from("testNonce"));
         let aud = Some(String::from("testAud"));
 
-        let presentation = SDJWTHolder::new(sd_jwt, format.clone())
+        let presentation = SDJWTHolder::new_unverified(sd_jwt, format.clone())
             .unwrap()
             .create_presentation(
                 user_claims.as_object().unwrap().clone(),
@@ -1080,7 +1086,7 @@ mod tests {
         let nonce = Some(String::from("testNonce"));
         let aud = Some(String::from("testAud"));
 
-        let presentation = SDJWTHolder::new(sd_jwt, SDJWTSerializationFormat::FlattenedJson)
+        let presentation = SDJWTHolder::new_unverified(sd_jwt, SDJWTSerializationFormat::FlattenedJson)
             .unwrap()
             .create_presentation(
                 user_claims.as_object().unwrap().clone(),
@@ -1209,7 +1215,7 @@ mod tests {
             SDJWTSerializationFormat::Compact,
         )
             .unwrap();
-        let presentation = SDJWTHolder::new(sd_jwt, SDJWTSerializationFormat::Compact)
+        let presentation = SDJWTHolder::new_unverified(sd_jwt, SDJWTSerializationFormat::Compact)
             .unwrap()
             .create_presentation(
                 user_claims.as_object().unwrap().clone(),
@@ -1274,7 +1280,7 @@ mod tests {
             )
             .unwrap();
 
-        let presentation = SDJWTHolder::new(sd_jwt, SDJWTSerializationFormat::Compact)
+        let presentation = SDJWTHolder::new_unverified(sd_jwt, SDJWTSerializationFormat::Compact)
             .unwrap()
             .create_presentation(
                 user_claims.as_object().unwrap().clone(),

--- a/tests/demos.rs
+++ b/tests/demos.rs
@@ -319,8 +319,13 @@ fn demo_positive_cases(
     )
         .unwrap();
     let issued = sd_jwt.clone();
-    // Holder creates presentation
-    let mut holder = SDJWTHolder::new(sd_jwt.clone(), format.clone()).unwrap();
+    let mut holder = SDJWTHolder::new(
+        sd_jwt.clone(),
+        format.clone(),
+        Box::new(|_, _| DecodingKey::from_ec_pem(ISSUER_PUBLIC_KEY.as_bytes()).unwrap()),
+    )
+    .unwrap();
+    // Holder creates presentation.
     let presentation = holder
         .create_presentation(
             holder_disclosed_claims,


### PR DESCRIPTION
## Problem

RFC 9901 §7.2 requires the Holder to validate the SD-JWT it receives from the
Issuer, which includes verifying the Issuer's signature:

> When receiving an SD-JWT, the Holder MUST do the following:
>
> 1. Process the SD-JWT as defined in Section 7.1 to validate it and extract the payload.
> 2. Ensure that the contents of claims in the payload are acceptable (depending on the application; for example, check that any values the Holder can check are correct).

and §7.1's processing steps include:

> Validate the signature over the Issuer-signed JWT per Section 5.2 of [RFC7515].

`SDJWTHolder::new` accepted the SD-JWT without verifying the Issuer signature
(a `TODO` marked the spot) and built presentations from unverified input.

## Change

- `SDJWTHolder::new` takes a new third parameter, `Box<KeyResolver>` [breaking]
  — required, consistent with `SDJWTVerifier::new`. It resolves the Issuer's
  public key from the unverified `iss` claim and the JWT header, then verifies
  the Issuer signature before the presentation state is built.
- `SDJWTHolder::new_unverified` is the explicit opt-out constructor: it skips
  Issuer-signature verification — for inputs already verified out of band or
  for test fixtures.
- `KeyResolver` is promoted from a private, verifier-local alias to one public
  type at the crate root, shared by the Holder and the Verifier.
- Call sites updated for the new parameter: README example, the generate
  tool, and tests.
- The signature check itself lives in a new `SDJWTCommon::verify_signature`:
  it requires the header `alg` (rejecting an absent or unknown algorithm),
  does not require `exp` (per §4.1, a present `exp` is still checked for
  expiry), honors a present `nbf` (matching the Verifier, per §7.1 step 6),
  and does not require an expected audience (an `aud` in the Issuer-signed
  JWT is the Issuer's audience, not one the Holder validates here).

## Test

- `new_accepts_valid_signature`: a validly issued SD-JWT passes.
- `new_rejects_tampered_signature`: corrupting the signature segment makes
  `SDJWTHolder::new` fail.
- `new_unverified_accepts_tampered_signature`: the explicit opt-out accepts an
  SD-JWT without any signature check, by design.
- `new_accepts_issuer_jwt_with_aud`: a validly-signed Issuer JWT carrying an
  `aud` claim is accepted.
- `new_rejects_issuer_jwt_with_future_nbf`: an SD-JWT whose `nbf` is in the
  future is rejected.
- `verify_full_presentation` and `verify_full_presentation_to_allow_other_algorithms`
  build their presentations through the verifying constructor, so the
  happy-path tests exercise the full flow including the Holder-side check.
- Full suite green: 232 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
